### PR TITLE
Integration forget password page

### DIFF
--- a/src/app/(auth)/forget-password/page.tsx
+++ b/src/app/(auth)/forget-password/page.tsx
@@ -1,7 +1,9 @@
 'use client'
 
 import Input from '@/components/login/input'
+import { apiRequest } from '@/services/api'
 import { validateEmail } from '@/utils/validation'
+import { useMutation } from '@tanstack/react-query'
 import Image from 'next/image'
 import { useRouter } from 'next/navigation'
 import { useEffect, useState } from 'react'
@@ -12,6 +14,24 @@ export default function ForgetPassword() {
   const router = useRouter()
   const [countdown, setCountdown] = useState('09:00')
   const [isButtonDisabled, setIsButtonDisabled] = useState(false)
+
+  const sendMailMutation = useMutation({
+    mutationFn: async (email: typeof userEmail) => {
+      try {
+        const response = await apiRequest(
+          'POST',
+          '/api/v1/auth/forgot-password',
+          { email }
+        )
+        return response
+      } catch (err) {
+        throw err
+      }
+    },
+    onSuccess: () => {
+      setIsButtonDisabled(true)
+    }
+  })
 
   useEffect(() => {
     let interval: any
@@ -50,7 +70,7 @@ export default function ForgetPassword() {
       setErrors({ email: 'Please enter a valid email address' })
       return
     }
-    setIsButtonDisabled(true)
+    sendMailMutation.mutate(userEmail)
   }
 
   return (

--- a/src/app/(auth)/reset-password-form/page.tsx
+++ b/src/app/(auth)/reset-password-form/page.tsx
@@ -1,11 +1,12 @@
 'use client'
 
 import Input from '@/components/login/input'
+import { specialCharacter, upperCaseOneCharacter } from '@/utils/validation'
 import Image from 'next/image'
 import { useRouter } from 'next/navigation'
 import { useState } from 'react'
 
-export default function ResetPassword() {
+export default function ResetPasswordForm() {
   const [userPassword, setUserPassword] = useState({
     password: '',
     confirmPassword: ''
@@ -66,19 +67,14 @@ export default function ResetPassword() {
     // Check password length
     else if (password.length < 6) {
       foundErrors.password = 'Password must be at least 6 characters'
-    }
-    // Check for at least one uppercase letter
-    else if (!/[A-Z]/.test(password)) {
+    } else if (!upperCaseOneCharacter(password)) {
       foundErrors.password =
         'Password must contain at least one uppercase letter'
-    }
-    // Check for at least one number or special character
-    else if (!/[0-9!@#$%^&*]/.test(password)) {
+    } else if (!specialCharacter(password)) {
       foundErrors.password =
         'Password must contain at least one number or special character'
     }
 
-    // Check if confirm password is empty or doesn't match the password
     if (!confirmPassword) {
       foundErrors.confirmPassword = 'Please confirm your password'
     } else if (confirmPassword !== password) {


### PR DESCRIPTION
- Integration forgot password page only
- Only can send email to **{"email":"abrahampurnomo144@gmail.com"}**
- Rename routes for reset-password to reset-password-form, because looking this thread slack 
https://konsulin.slack.com/archives/C071WN77QJZ/p1721575123744319
  

**API contract**
[Forgot Password](https://documenter.getpostman.com/view/34502980/2sA3e5eoRg#5777a09e-b7ed-4908-9b2e-1e17a7e90459)

**payload**
![payload](https://github.com/user-attachments/assets/4cd11164-9623-4b1b-9e70-ea5bcae6c236)

**if send with another email**
![err](https://github.com/user-attachments/assets/af3c8f13-5214-47af-991b-1ddef09418b3)
