### PR TITLE
Resolve login issue

### DIFF
--- a/src/services/profile.tsx
+++ b/src/services/profile.tsx
@@ -40,7 +40,7 @@ export const getProfileByIdentifier = async ({ userId, type }) => {
   try {
     const response = await apiRequest<AxiosResponse>(
       'GET',
-      `/fhir/${type}?identifier=${userId}`
+      `/fhir/${type}?identifier=https://login.konsulin.care/userid|${userId}`
     );
 
     const entries = response?.data?.entry;


### PR DESCRIPTION
The previous issue occurs because the backend enforces the use of 'system' when looking for patient resources by its identifier. This fix includes the hardcoded system to the request.