### PR TITLE
fix: force redirect to auth to apply authenticated view

### DIFF
--- a/src/config/frontendConfig.ts
+++ b/src/config/frontendConfig.ts
@@ -101,7 +101,13 @@ export const frontendConfig = (): SuperTokensConfig => {
 
               await setCookies('auth', JSON.stringify(cookieData));
             }
-            routerInfo.router.refresh();
+
+            const isAuthRoute = (routerInfo.pathName || '').startsWith('/auth');
+            if (!isAuthRoute) {
+              routerInfo.router.push('/auth');
+              await new Promise(resolve => setTimeout(resolve, 100));
+            }
+            window.location.href = '/';
           }
         }
       })


### PR DESCRIPTION
## Summary

Force redirect to `/auth` and then after that back to the homepage after  magic link is successfully consumed.

## Purpose

This changes is a necessary complement to proposed fix related to the authentication feature from supertoken [in this pull request.](https://github.com/konsulin-care/konsulin-api/pull/215) because even after success consuming the magic link, the app won't show the authenticated webview. The user must manually go back to `/auth` in order the authentication result to take effect.

## Steps To Reproduce

1. go to [https://dev-app.konsulin.care/](`https://dev-app.konsulin.care/`) and sign up using fresh email
2. go to your email and then access the given magic link
3. after a brief wait, the app still show non-authenticated web view like the image below

<img width="1284" height="1025" alt="image" src="https://github.com/user-attachments/assets/05cc8c49-fcb3-4a58-b222-324a3a7a297f" />

## Testing

The testing of this changes was done using two ways, first running using locally installed nodejs and using docker. both basically yield the same result. The testing done using the same way as the steps in <strong>Steps To Reproduce</strong>. However, upon clicking the magic link and observing the webview result, below are the webview shown by the app

<img width="1216" height="1027" alt="image" src="https://github.com/user-attachments/assets/a30d4248-0335-47f1-a0b4-3bac4431f083" />

## Configuration

this PR isn't requiring new configuration values

## Note

This PR will complement the PR in [this backend PR](https://github.com/konsulin-care/konsulin-api/pull/215)