### PR TITLE
style: use white background to avoid transparent dropdown

### DIFF
--- a/src/components/profile/dropdown-profile.tsx
+++ b/src/components/profile/dropdown-profile.tsx
@@ -74,14 +74,14 @@ const DropdownProfile: React.FC<DropdownProps> = ({
         </DropdownTrigger>
         <DropdownContent
           style={{ minWidth: triggerWidth }}
-          className='max-h-60 overflow-y-auto'
+          className='max-h-60 overflow-y-auto bg-white'
         >
           {options &&
             options.map(item => (
               <DropdownItem
                 key={item.code}
                 onSelect={() => onSelect(item)}
-                className={`w-full ${
+                className={`w-full bg-white hover:bg-gray-50 focus:bg-gray-100 ${
                   value === item.code ? 'bg-secondary text-white' : ''
                 }`}
               >


### PR DESCRIPTION
use white background on all dropdown in update profile (gender, provinces, cities and district form value) to avoid transparent background that causing confusion when selecting option in the form

<img width="878" height="450" alt="Screenshot 2025-10-19 172800" src="https://github.com/user-attachments/assets/af7a8e0a-692b-4753-9936-d1470eb29357" />
<img width="868" height="432" alt="Screenshot 2025-10-19 172752" src="https://github.com/user-attachments/assets/bcad6860-3522-403b-980b-36c018905b55" />
<img width="857" height="466" alt="Screenshot 2025-10-19 172743" src="https://github.com/user-attachments/assets/0c914fd8-bc48-47df-b66c-20d6094c72d8" />
<img width="840" height="322" alt="Screenshot 2025-10-19 172735" src="https://github.com/user-attachments/assets/51c4cbed-ed45-4d15-aa5e-6bc9c7eda0a3" />
