### PR TITLE
fix: only creating new profile if not yet exists

### DIFF
--- a/src/config/frontendConfig.ts
+++ b/src/config/frontendConfig.ts
@@ -72,22 +72,28 @@ export const frontendConfig = (): SuperTokensConfig => {
               })) as Patient | Practitioner;
 
               if (!profileData) {
-                // Create FHIR Profile for new user
-                await createProfile({
-                  userId,
-                  email: emails[0],
-                  type: roles.includes('Practitioner')
-                    ? 'Practitioner'
-                    : 'Patient'
-                });
+                try {
+                  // Create FHIR Profile for new user
+                  await createProfile({
+                    userId,
+                    email: emails[0],
+                    type: roles.includes('Practitioner')
+                      ? 'Practitioner'
+                      : 'Patient'
+                  });
 
-                // re-fetch the profile data
-                profileData = (await getProfileByIdentifier({
-                  userId,
-                  type: roles.includes('Practitioner')
-                    ? 'Practitioner'
-                    : 'Patient'
-                })) as Patient | Practitioner;
+                  // re-fetch the profile data
+                  profileData = (await getProfileByIdentifier({
+                    userId,
+                    type: roles.includes('Practitioner')
+                      ? 'Practitioner'
+                      : 'Patient'
+                  })) as Patient | Practitioner;
+
+                  if (!profileData) throw new Error('Failed to create profile');
+                } catch (error) {
+                  throw error;
+                }
               }
 
               const cookieData = {


### PR DESCRIPTION
# This PR is not yet ready to be merged

This PR will depends on the new, fixed ownership checking [in this PR](https://github.com/konsulin-care/konsulin-api/pull/250) and also the new changes that made backend responsible to initialize FHIR resource creation [here](https://github.com/konsulin-care/konsulin-api/pull/253).. Until that PRds are merged, this PR should not be merged. However, this PR is open for review.

## Summary

Making frontend-initatied resource creation is a backup because the responsibility to initialize the FHIR profile resource now recedes on backend server.

## Purpose

This PR attempts to solve these issues: https://github.com/konsulin-care/konsulin-api/issues/246 and https://github.com/konsulin-care/konsulin-app/issues/263

## Testing

This changes has been tested as part of the testing [in this PR](https://github.com/konsulin-care/konsulin-api/pull/253). If some test differ or not yet included in there, will be added to here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More reliable first-time profile setup: the system now ensures profile data is fetched and created as needed, with improved error detection and fallback so new users' profiles initialize consistently.
  * Safer cookie/profile data handling to reduce failures during initial login.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->