### PR TITLE
Add DeepWiki badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 </p>
 
 <p align="center">
+  <a href="https://deepwiki.com/konsulin-care/konsulin-app"><img src="https://deepwiki.com/badge.svg" alt="Ask DeepWiki"></a>
   <a href="https://github.com/konsulin-care/konsulin-app/releases"><img src="https://img.shields.io/github/v/release/konsulin-care/konsulin-app?style=flat" alt="GitHub release (with filter)"></a>
   <a href="https://github.com/konsulin-care/konsulin-app/actions"><img src="https://img.shields.io/github/actions/workflow/status/konsulin-care/konsulin-app/main.yml?style=flat" alt="GitHub Workflow Status (with event)"></a>
   <a href="https://hl7.org/fhir/R4"><img src="https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fapi.konsulin.care%2Ffhir%2Fmetadata&query=%24.fhirVersion&label=FHIR&color=red" alt="Blaze"></a>


### PR DESCRIPTION
### **User description**
Added a badge for DeepWiki to the README.


___

### **PR Type**
Documentation


___

### **Description**
- Added DeepWiki badge link to README

- Badge directs to DeepWiki documentation page

- Positioned before existing GitHub release badge


___

### Diagram Walkthrough


```mermaid
flowchart LR
  README["README.md"] -- "add DeepWiki badge link" --> BADGE["DeepWiki Badge"]
  BADGE -- "links to" --> DEEPWIKI["DeepWiki Documentation"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Add DeepWiki documentation badge</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

README.md

<ul><li>Added a new hyperlinked badge for DeepWiki<br> <li> Badge image sourced from <code>https://deepwiki.com/badge.svg</code><br> <li> Link points to DeepWiki documentation for konsulin-app<br> <li> Inserted at the beginning of the badges section</ul>


</details>


  </td>
  <td><a href="https://github.com/konsulin-care/konsulin-app/pull/372/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

