### PR TITLE
feat: add capability to redirect user based on redirection target in magic link URL

### DIFF
--- a/src/config/frontendConfig.ts
+++ b/src/config/frontendConfig.ts
@@ -2,6 +2,7 @@ import { setCookies } from '@/app/actions';
 import { Roles } from '@/constants/roles';
 import { createProfile, getProfileByIdentifier } from '@/services/profile';
 import { mergeNames } from '@/utils/helper';
+import { extractSafeRedirectPath } from '@/utils/redirect-guard';
 import { Patient, Practitioner } from 'fhir/r4';
 import { useRouter } from 'next/navigation';
 import React from 'react';
@@ -232,7 +233,21 @@ export const frontendConfig = (): SuperTokensConfig => {
               routerInfo.router.push('/auth');
               await new Promise(resolve => setTimeout(resolve, 100));
             }
-            window.location.href = '/';
+
+            const redirectToPath = extractSafeRedirectPath(
+              window.location.search
+            );
+            if (redirectToPath) {
+              console.log(
+                '[auth:redirect] redirecting to magic link target:',
+                redirectToPath
+              );
+            } else {
+              console.log(
+                '[auth:redirect] no valid redirectToPath found, defaulting to /'
+              );
+            }
+            window.location.href = redirectToPath ?? '/';
           }
         }
       })

--- a/src/config/frontendConfig.ts
+++ b/src/config/frontendConfig.ts
@@ -229,14 +229,13 @@ export const frontendConfig = (): SuperTokensConfig => {
             }
 
             const isAuthRoute = (routerInfo.pathName || '').startsWith('/auth');
+            const redirectToPath = extractSafeRedirectPath(
+              window.location.search
+            );
             if (!isAuthRoute) {
               routerInfo.router.push('/auth');
               await new Promise(resolve => setTimeout(resolve, 100));
             }
-
-            const redirectToPath = extractSafeRedirectPath(
-              window.location.search
-            );
             if (redirectToPath) {
               console.log(
                 '[auth:redirect] redirecting to magic link target:',

--- a/src/config/frontendConfig.ts
+++ b/src/config/frontendConfig.ts
@@ -230,7 +230,7 @@ export const frontendConfig = (): SuperTokensConfig => {
 
             const isAuthRoute = (routerInfo.pathName || '').startsWith('/auth');
             const redirectToPath = extractSafeRedirectPath(
-              window.location.search
+              globalThis.location.search
             );
             if (!isAuthRoute) {
               routerInfo.router.push('/auth');
@@ -246,7 +246,7 @@ export const frontendConfig = (): SuperTokensConfig => {
                 '[auth:redirect] no valid redirectToPath found, defaulting to /'
               );
             }
-            window.location.href = redirectToPath ?? '/';
+            globalThis.location.href = redirectToPath ?? '/';
           }
         }
       })

--- a/src/utils/redirect-guard.test.ts
+++ b/src/utils/redirect-guard.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+import { extractSafeRedirectPath } from './redirect-guard';
+
+describe('extractSafeRedirectPath', () => {
+  it('returns internal path when valid', () => {
+    expect(
+      extractSafeRedirectPath('?redirectToPath=%2Fjournal%3Ftab%3D1')
+    ).toBe('/journal?tab=1');
+  });
+
+  it('returns internal path when valid2', () => {
+    expect(
+      extractSafeRedirectPath(
+        '?redirectToPath=%2Fassessments%3FisDrawerOpen%3Dtrue%26assessmentId%3Dsomeidhere'
+      )
+    ).toBe('/assessments?isDrawerOpen=true&assessmentId=someidhere');
+  });
+
+  it('rejects protocol-relative payload', () => {
+    expect(
+      extractSafeRedirectPath('?redirectToPath=%2F%2Fevil.com')
+    ).toBeNull();
+  });
+
+  it('rejects backslash payload', () => {
+    expect(
+      extractSafeRedirectPath('?redirectToPath=%2F%5Cevil.com')
+    ).toBeNull();
+  });
+
+  it('rejects control whitespace payload', () => {
+    expect(
+      extractSafeRedirectPath('?redirectToPath=%2F%0D%0A%2F%2Fevil.com')
+    ).toBeNull();
+  });
+
+  it('rejects encoded double-slash path payload', () => {
+    expect(
+      extractSafeRedirectPath('?redirectToPath=%2F%252F%252Fevil.com')
+    ).toBeNull();
+  });
+});

--- a/src/utils/redirect-guard.ts
+++ b/src/utils/redirect-guard.ts
@@ -29,6 +29,22 @@ export function extractSafeRedirectPath(search: string): string | null {
     return null;
   }
 
+  if (path.includes('\\')) {
+    console.warn(
+      '[auth:redirect] redirectToPath rejected: backslashes are not allowed',
+      path
+    );
+    return null;
+  }
+
+  if (/[\r\n\t]/.test(path)) {
+    console.warn(
+      '[auth:redirect] redirectToPath rejected: control whitespace is not allowed',
+      path
+    );
+    return null;
+  }
+
   if (path.includes('://')) {
     console.warn(
       '[auth:redirect] redirectToPath rejected: contains a URL scheme',
@@ -53,5 +69,47 @@ export function extractSafeRedirectPath(search: string): string | null {
     return null;
   }
 
-  return path;
+  try {
+    const parsed = new URL(path, window.location.origin);
+    if (parsed.origin !== window.location.origin) {
+      console.warn(
+        '[auth:redirect] redirectToPath rejected: cross-origin redirect is not allowed',
+        path
+      );
+      return null;
+    }
+
+    const normalized = `${parsed.pathname}${parsed.search}${parsed.hash}`;
+    if (normalized.length > REDIRECT_PATH_MAX_LENGTH) {
+      console.warn(
+        `[auth:redirect] redirectToPath rejected after normalization: exceeds max length of ${REDIRECT_PATH_MAX_LENGTH} characters`
+      );
+      return null;
+    }
+
+    if (normalized.startsWith('//')) {
+      console.warn(
+        '[auth:redirect] redirectToPath rejected after normalization: protocol-relative URL not allowed',
+        normalized
+      );
+      return null;
+    }
+
+    const decoded = decodeURIComponent(normalized);
+    if (decoded.startsWith('//')) {
+      console.warn(
+        '[auth:redirect] redirectToPath rejected: decodes to protocol-relative URL',
+        normalized
+      );
+      return null;
+    }
+
+    return normalized;
+  } catch {
+    console.warn(
+      '[auth:redirect] redirectToPath rejected: URL parsing failed',
+      path
+    );
+    return null;
+  }
 }

--- a/src/utils/redirect-guard.ts
+++ b/src/utils/redirect-guard.ts
@@ -1,0 +1,57 @@
+const REDIRECT_PATH_MAX_LENGTH = 256;
+
+/**
+ * Extracts and validates the `redirectToPath` query parameter from a URL search string.
+ *
+ * Enforces strict internal-only rules:
+ * - Must start with "/" (relative path only)
+ * - Must not start with "//" (protocol-relative URL)
+ * - Must not contain "://" (absolute URL with any scheme)
+ * - Must not exceed 256 characters
+ *
+ * Returns the safe path string, or null if the value is absent, empty, or fails any rule.
+ * All rejections are logged for debugging.
+ */
+export function extractSafeRedirectPath(search: string): string | null {
+  const params = new URLSearchParams(search);
+  const raw = params.get('redirectToPath');
+
+  if (!raw || raw.trim() === '') {
+    return null;
+  }
+
+  const path = raw.trim();
+
+  if (path.length > REDIRECT_PATH_MAX_LENGTH) {
+    console.warn(
+      `[auth:redirect] redirectToPath rejected: exceeds max length of ${REDIRECT_PATH_MAX_LENGTH} characters`
+    );
+    return null;
+  }
+
+  if (path.includes('://')) {
+    console.warn(
+      '[auth:redirect] redirectToPath rejected: contains a URL scheme',
+      path
+    );
+    return null;
+  }
+
+  if (path.startsWith('//')) {
+    console.warn(
+      '[auth:redirect] redirectToPath rejected: protocol-relative URL not allowed',
+      path
+    );
+    return null;
+  }
+
+  if (!path.startsWith('/')) {
+    console.warn(
+      '[auth:redirect] redirectToPath rejected: must be a relative path starting with /',
+      path
+    );
+    return null;
+  }
+
+  return path;
+}

--- a/src/utils/redirect-guard.ts
+++ b/src/utils/redirect-guard.ts
@@ -70,8 +70,8 @@ export function extractSafeRedirectPath(search: string): string | null {
   }
 
   try {
-    const parsed = new URL(path, window.location.origin);
-    if (parsed.origin !== window.location.origin) {
+    const parsed = new URL(path, globalThis.location.origin);
+    if (parsed.origin !== globalThis.location.origin) {
       console.warn(
         '[auth:redirect] redirectToPath rejected: cross-origin redirect is not allowed',
         path


### PR DESCRIPTION
## Summary

After each sucessful auth from magic link, will attempt to detect whether a specialized `redirectToPath` params exists on magic link or not. If it is exists, the app will attempt to make that redirection target be the first page which user land right after authentication has finished.

## Purpose

To honor the embedded redirection target set by the backend and allow for more complete business usecase.

## Note

I choose not to use supertokens' hook: `getRedirectionURL` because it is actually able to cause race conditions where `onHandleEvent` might not finished before supertokens's `getRedirectionURL` fires. This is because `onHandleEvent` is an async process, thus we can't guarantee all effect inside `onHandleEvent` finish before `getRedirectionURL`. Current `onHandleEvent` is also already contain redirection logic, thus, it is actually safer to add the new capability there.

## Testing

### Case 1: No redirection target embedded in the link

When no redirection target found, default to redirect the user to app's main page.

generated magic link:
`http://localhost:3000/auth/verify?preAuthSessionId=auguXsTGJpNkPIZJefjOMUwnqd3sociFlpA2AEOfUeI&tenantId=public#D_pRtCfg1j7ZKnmQDz2W-F6a1Dr2gQC0fZGwN3DUBeo`

result:
<img width="1512" height="910" alt="image" src="https://github.com/user-attachments/assets/a5af47d7-4272-4066-8b3b-99648b490670" />

### Case 2: redirecting the user to appointment detail page

If the redirection params embedded with appointment id, redirecgt the user to the appointment detail page.

generated magic link:
`http://localhost:3000/auth/verify?preAuthSessionId=IYII6SQUlL0Em8v26MrSAeYOgeLmczl1y4Nvuy9UZ1o&tenantId=public&redirectToPath=%2Fschedule%2F235a6298-d0c7-43f0-b9d3-4e5fe761da72#0bP13St4hS68ZbkiurFOgRYdTYe-O_DTAz_E3hSsx1M%60`

result:
<img width="1364" height="909" alt="image" src="https://github.com/user-attachments/assets/9ff6e00a-3562-462c-a8bc-25bdf4c254b4" />

### Case 3: Redirect to clinics list page

When the redirection path target is set to the clinics list page, redirect the user to that page right after sucessful auth process.

generated magic link:
`http://localhost:3000/auth/verify?preAuthSessionId=Z9EdNsZ8owJcaawSv0mX8j7Bxzko5QqYmShagGfvYAY&tenantId=public&redirectToPath=%2Fclinic#UfeEJ0nWw2so7RkgeYMsGFMkktbI3qi0g2DWxGy_O0w`

result:
<img width="1512" height="918" alt="image" src="https://github.com/user-attachments/assets/ff6c422d-af2d-42f9-a0a3-c6b878468915" />

### Case 4: redirect to a specific assesments page

When the redirection path is set to a specific assesment id, the app should redirect the user to the assesment page and skip the confirmation modal so that the user can directly give answers to the assesment

generated magic link:
`http://localhost:3000/auth/verify?preAuthSessionId=r2145lgFNXttOcLoUPfkHkoO_8gRwfdMSSy9e8v_Bjg&tenantId=public&redirectToPath=%2Fassessments%2FDHQCZ4BG7OBLPI53#zMHKKdD_kdqYWfb_5OHKrsHRyliOFLqheYIdhntow7k`

result:
<img width="1512" height="909" alt="image" src="https://github.com/user-attachments/assets/908a7f60-35c3-4e95-a221-7e4e19805d5a" />


### Case 5: redirect to an assessment filling confirmation (modal pop up)

When the magic link was embedded with a redirection target to an assesment detail page (modal popup containing assesment detail), ensure to make the user redirected only up to that part (not the direct answering like above example)

generated magic link:
`http://localhost:3000/auth/verify?preAuthSessionId=BXHz__RdZNgHAFQYZ7Xo0ULwHTTs1YmU1yHEg8_WeY4&tenantId=public&redirectToPath=%2Fassessments%3FisDrawerOpen%3Dtrue%26assessmentId%3DDHQCZ4BG7OBLPI53#-Y_ZzJX2U6n7YmHVajx8PCEqrhfoOyZVeQw_P7WkZ74`

result:
<img width="1512" height="910" alt="image" src="https://github.com/user-attachments/assets/2e340217-2030-4cae-902d-a8cc4212d358" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Passwordless login now honors validated redirect query parameters and sends users to the intended in-app page after authentication instead of always returning to the home page.

* **Tests**
  * Added tests covering allowed and rejected redirect paths to ensure unsafe or external redirects are blocked.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/konsulin-care/konsulin-app/pull/572)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->