### PR TITLE
feat(pwa): finalize offline PWA support

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -36,5 +36,18 @@ jobs:
       - name: Install npm dependencies
         run: npm ci
 
+      - name: Lint changed JS/TS files
+        run: |
+          BASE_SHA="${{ github.event.pull_request.base.sha }}"
+          git fetch origin "$BASE_SHA" --depth=1
+          CHANGED="$(git diff --name-only "$BASE_SHA" HEAD --diff-filter=ACMR | grep -E '\.(js|jsx|ts|tsx)$' || true)"
+          if [ -n "$CHANGED" ]; then
+            echo "Linting changed files:"
+            printf '%s\n' "$CHANGED"
+            printf '%s\n' "$CHANGED" | xargs npx eslint --max-warnings 5
+          else
+            echo "No changed JS/TS files to lint"
+          fi
+
       - name: Run Next.js build
         run: npm run build

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -17,12 +17,6 @@ if ! npm run typecheck; then
   exit 1
 fi
 
-# Type-check the whole project
-if ! (npx tsc --noEmit); then
-  echo "  TypeScript errors found. Fix them and try again."
-  exit 1
-fi
-
 # Lint staged JS/TS files — fail commit on any error
 if ! npx --no-install lint-staged; then
   echo "  Lint-staged failed, do npm install and try again"

--- a/eslint.config.cjs
+++ b/eslint.config.cjs
@@ -237,6 +237,14 @@ module.exports = [
     }
   },
 
+  // --- PWA status live-regions: prefer <output> over role="status" (SonarQube) ---
+  {
+    files: ['src/components/pwa/**/*.tsx'],
+    rules: {
+      'jsx-a11y/prefer-tag-over-role': 'error'
+    }
+  },
+
   // --- Test & third-party UI: no JSDoc required (auto-generated or test helpers) ---
   {
     files: [

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,5 +1,5 @@
 /* eslint-disable unicorn/prefer-global-this */
-const SW_VERSION = '1';
+const SW_VERSION = '2';
 const STATIC_CACHE = `konsulin-static-v${SW_VERSION}`;
 const NAV_CACHE = `konsulin-nav-v${SW_VERSION}`;
 const OFFLINE_URL = '/~offline';
@@ -107,6 +107,23 @@ function isProxyApi(pathname) {
   return pathname.startsWith('/proxy/');
 }
 
+/**
+ * Checks if a pathname targets a cacheable proxy Questionnaire read.
+ * The negative guard matters: QuestionnaireResponse also starts with
+ * Questionnaire but must stay network-only.
+ */
+function isCachedProxyApi(pathname) {
+  return (
+    pathname.startsWith('/proxy/fhir/Questionnaire') &&
+    !pathname.startsWith('/proxy/fhir/QuestionnaireResponse')
+  );
+}
+
+/** Checks if a pathname targets an auth/config endpoint (never cached). */
+function isAuthApi(pathname) {
+  return pathname.startsWith('/auth/') || pathname === '/api/config';
+}
+
 /** Network-first strategy: tries network, falls back to cache, then to offline fallback URL. */
 async function networkFirst(request, cacheName, fallbackUrl) {
   try {
@@ -156,7 +173,17 @@ self.addEventListener('fetch', function (event) {
         // Non-GET requests bypass caching entirely.
         if (request.method !== 'GET') return fetch(request);
 
-        if (isProxyApi(url.pathname)) return fetch(request);
+        // Auth/config endpoints carry identity data — never cached.
+        if (isAuthApi(url.pathname)) return fetch(request);
+
+        if (isProxyApi(url.pathname)) {
+          // Only Questionnaire reads are cached (network-first); all other
+          // proxy traffic (incl. QuestionnaireResponse) stays network-only.
+          if (isCachedProxyApi(url.pathname)) {
+            return await networkFirst(request, NAV_CACHE);
+          }
+          return fetch(request);
+        }
 
         if (request.mode === 'navigate') {
           return await networkFirst(request, NAV_CACHE, OFFLINE_URL);

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,24 +1,38 @@
 /* eslint-disable unicorn/prefer-global-this */
-const SW_VERSION = '1'
-const STATIC_CACHE = `konsulin-static-v${SW_VERSION}`
-const NAV_CACHE = `konsulin-nav-v${SW_VERSION}`
-const OFFLINE_URL = '/~offline'
+const SW_VERSION = '1';
+const STATIC_CACHE = `konsulin-static-v${SW_VERSION}`;
+const NAV_CACHE = `konsulin-nav-v${SW_VERSION}`;
+const OFFLINE_URL = '/~offline';
 
 const PRECACHE_URLS = [
   OFFLINE_URL,
   '/manifest.json',
   '/images/Loading-Time.svg'
-]
+];
 
 self.addEventListener('install', function (event) {
   // NOSONAR - self is SW global scope
   event.waitUntil(
     caches.open(STATIC_CACHE).then(function (cache) {
-      return cache.addAll(PRECACHE_URLS)
+      return cache.addAll(PRECACHE_URLS);
     })
-  )
-  self.skipWaiting() // NOSONAR - self is SW global scope
-})
+  );
+  self.skipWaiting(); // NOSONAR - self is SW global scope
+});
+
+self.addEventListener('sync', function (event) {
+  // NOSONAR - self is SW global scope
+  if (event.tag !== 'replay-pending') return;
+  event.waitUntil(
+    self.clients.matchAll().then(function (clients) {
+      return Promise.all(
+        clients.map(function (client) {
+          return client.postMessage({ type: 'SYNC_REPLAY' });
+        })
+      );
+    })
+  );
+});
 
 self.addEventListener('activate', function (event) {
   event.waitUntil(
@@ -32,124 +46,124 @@ self.addEventListener('activate', function (event) {
                 key.startsWith('konsulin-') &&
                 key !== STATIC_CACHE &&
                 key !== NAV_CACHE
-              )
+              );
             })
             .map(function (key) {
-              return caches.delete(key)
+              return caches.delete(key);
             })
-        )
+        );
       })
       .then(function () {
-        return self.clients.claim() // NOSONAR - self is SW global scope
+        return self.clients.claim(); // NOSONAR - self is SW global scope
       })
-  )
-})
+  );
+});
 
 /**
  * Parse a URL string safely, returning null on invalid input.
  * Avoids try-catch so SonarCloud doesn't flag unhandled exceptions.
  */
-function parseUrl (url) {
+function parseUrl(url) {
   try {
-    return new URL(url)
+    return new URL(url);
   } catch {
-    return null
+    return null;
   }
 }
 
 /** Checks if a URL uses http or https protocol. */
-function isValidHttpUrl (url) {
-  const parsed = parseUrl(url)
+function isValidHttpUrl(url) {
+  const parsed = parseUrl(url);
   return (
     parsed !== null &&
     (parsed.protocol === 'http:' || parsed.protocol === 'https:')
-  )
+  );
 }
 
 /** Checks if a URL belongs to the same origin. */
-function isSameOrigin (url) {
-  return url.origin === self.location.origin // NOSONAR - self is SW global scope
+function isSameOrigin(url) {
+  return url.origin === self.location.origin; // NOSONAR - self is SW global scope
 }
 
 /** Checks if a pathname is a precacheable static asset. */
-function isStaticAsset (pathname) {
+function isStaticAsset(pathname) {
   return (
     pathname.startsWith('/_next/static/') ||
     pathname.startsWith('/favicon/') ||
     pathname.startsWith('/icons/') ||
     pathname.startsWith('/images/')
-  )
+  );
 }
 
 /** Checks if a pathname targets the proxy API. */
-function isProxyApi (pathname) {
-  return pathname.startsWith('/proxy/')
+function isProxyApi(pathname) {
+  return pathname.startsWith('/proxy/');
 }
 
 /** Network-first strategy: tries network, falls back to cache, then to offline fallback URL. */
-async function networkFirst (request, cacheName, fallbackUrl) {
+async function networkFirst(request, cacheName, fallbackUrl) {
   try {
     if (!isValidHttpUrl(request.url)) {
-      throw new Error('Invalid URL: only http/https URLs are allowed')
+      throw new Error('Invalid URL: only http/https URLs are allowed');
     }
 
     // skipcq: JS-0376 - NOSONAR - URL validated by isValidHttpUrl() guard above
-    const response = await fetch(request)
+    const response = await fetch(request);
     if (response.ok && request.method === 'GET') {
-      const navCache = await caches.open(cacheName)
-      await navCache.put(request, response.clone())
+      const navCache = await caches.open(cacheName);
+      await navCache.put(request, response.clone());
     }
-    return response
+    return response;
   } catch {
     try {
-      const fallbackCache = await caches.open(cacheName)
-      const cached = await fallbackCache.match(request)
-      if (cached) return cached
+      const fallbackCache = await caches.open(cacheName);
+      const cached = await fallbackCache.match(request);
+      if (cached) return cached;
       if (fallbackUrl) {
-        const staticCache = await caches.open(STATIC_CACHE)
-        const fallback = await staticCache.match(fallbackUrl)
-        if (fallback) return fallback
+        const staticCache = await caches.open(STATIC_CACHE);
+        const fallback = await staticCache.match(fallbackUrl);
+        if (fallback) return fallback;
       }
     } catch {
-      console.warn('[SW] cache fallback failed for', request.url)
+      console.warn('[SW] cache fallback failed for', request.url);
     }
     // Graceful degradation instead of throwing
-    return new Response('Service Unavailable', { status: 503 })
+    return new Response('Service Unavailable', { status: 503 });
   }
 }
 
 self.addEventListener('fetch', function (event) {
-  const url = parseUrl(event.request.url)
+  const url = parseUrl(event.request.url);
   if (!url) {
-    return
+    return;
   }
 
   // Skip cross-origin requests — let the browser handle them directly.
-  if (!isSameOrigin(url)) return
+  if (!isSameOrigin(url)) return;
 
   event.respondWith(
     (async function () {
       try {
-        const request = event.request
+        const request = event.request;
 
         // Non-GET requests bypass caching entirely.
-        if (request.method !== 'GET') return fetch(request)
+        if (request.method !== 'GET') return fetch(request);
 
-        if (isProxyApi(url.pathname)) return fetch(request)
+        if (isProxyApi(url.pathname)) return fetch(request);
 
         if (request.mode === 'navigate') {
-          return await networkFirst(request, NAV_CACHE, OFFLINE_URL)
+          return await networkFirst(request, NAV_CACHE, OFFLINE_URL);
         }
 
         if (isStaticAsset(url.pathname)) {
-          return await networkFirst(request, STATIC_CACHE)
+          return await networkFirst(request, STATIC_CACHE);
         }
 
-        return await networkFirst(request, NAV_CACHE)
+        return await networkFirst(request, NAV_CACHE);
       } catch (error) {
-        console.warn('[SW] fetch handler error:', error)
-        return new Response('Service Unavailable', { status: 503 })
+        console.warn('[SW] fetch handler error:', error);
+        return new Response('Service Unavailable', { status: 503 });
       }
     })()
-  )
-})
+  );
+});

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,46 +1,46 @@
 /* eslint-disable unicorn/prefer-global-this */
-const SW_VERSION = '2';
-const STATIC_CACHE = `konsulin-static-v${SW_VERSION}`;
-const NAV_CACHE = `konsulin-nav-v${SW_VERSION}`;
-const OFFLINE_URL = '/~offline';
+const SW_VERSION = '2'
+const STATIC_CACHE = `konsulin-static-v${SW_VERSION}`
+const NAV_CACHE = `konsulin-nav-v${SW_VERSION}`
+const OFFLINE_URL = '/~offline'
 
 const PRECACHE_URLS = [
   OFFLINE_URL,
   '/manifest.json',
   '/images/Loading-Time.svg'
-];
+]
 
 self.addEventListener('install', function (event) {
   // NOSONAR - self is SW global scope
   event.waitUntil(
     caches.open(STATIC_CACHE).then(function (cache) {
-      return cache.addAll(PRECACHE_URLS);
+      return cache.addAll(PRECACHE_URLS)
     })
-  );
-  self.skipWaiting(); // NOSONAR - self is SW global scope
-});
+  )
+  self.skipWaiting() // NOSONAR - self is SW global scope
+})
 
 self.addEventListener('sync', function (event) {
   // NOSONAR - self is SW global scope
-  if (event.tag !== 'replay-pending') return;
+  if (event.tag !== 'replay-pending') return
   event.waitUntil(
     self.clients.matchAll().then(function (clients) {
       return Promise.all(
         clients.map(function (client) {
-          return client.postMessage({ type: 'SYNC_REPLAY' });
+          return client.postMessage({ type: 'SYNC_REPLAY' })
         })
-      );
+      )
     })
-  );
-});
+  )
+})
 
 self.addEventListener('message', function (event) {
   // NOSONAR - self is SW global scope
-  if (event.origin !== self.location.origin) return;
+  if (event.origin !== self.location.origin) return
   if (event.data?.type === 'SKIP_WAITING') {
-    self.skipWaiting();
+    self.skipWaiting()
   }
-});
+})
 
 self.addEventListener('activate', function (event) {
   event.waitUntil(
@@ -54,58 +54,58 @@ self.addEventListener('activate', function (event) {
                 key.startsWith('konsulin-') &&
                 key !== STATIC_CACHE &&
                 key !== NAV_CACHE
-              );
+              )
             })
             .map(function (key) {
-              return caches.delete(key);
+              return caches.delete(key)
             })
-        );
+        )
       })
       .then(function () {
-        return self.clients.claim(); // NOSONAR - self is SW global scope
+        return self.clients.claim() // NOSONAR - self is SW global scope
       })
-  );
-});
+  )
+})
 
 /**
  * Parse a URL string safely, returning null on invalid input.
  * Avoids try-catch so SonarCloud doesn't flag unhandled exceptions.
  */
-function parseUrl(url) {
+function parseUrl (url) {
   try {
-    return new URL(url);
+    return new URL(url)
   } catch {
-    return null;
+    return null
   }
 }
 
 /** Checks if a URL uses http or https protocol. */
-function isValidHttpUrl(url) {
-  const parsed = parseUrl(url);
+function isValidHttpUrl (url) {
+  const parsed = parseUrl(url)
   return (
     parsed !== null &&
     (parsed.protocol === 'http:' || parsed.protocol === 'https:')
-  );
+  )
 }
 
 /** Checks if a URL belongs to the same origin. */
-function isSameOrigin(url) {
-  return url.origin === self.location.origin; // NOSONAR - self is SW global scope
+function isSameOrigin (url) {
+  return url.origin === self.location.origin // NOSONAR - self is SW global scope
 }
 
 /** Checks if a pathname is a precacheable static asset. */
-function isStaticAsset(pathname) {
+function isStaticAsset (pathname) {
   return (
     pathname.startsWith('/_next/static/') ||
     pathname.startsWith('/favicon/') ||
     pathname.startsWith('/icons/') ||
     pathname.startsWith('/images/')
-  );
+  )
 }
 
 /** Checks if a pathname targets the proxy API. */
-function isProxyApi(pathname) {
-  return pathname.startsWith('/proxy/');
+function isProxyApi (pathname) {
+  return pathname.startsWith('/proxy/')
 }
 
 /**
@@ -113,92 +113,92 @@ function isProxyApi(pathname) {
  * The negative guard matters: QuestionnaireResponse also starts with
  * Questionnaire but must stay network-only.
  */
-function isCachedProxyApi(pathname) {
+function isCachedProxyApi (pathname) {
   return (
     pathname.startsWith('/proxy/fhir/Questionnaire') &&
     !pathname.startsWith('/proxy/fhir/QuestionnaireResponse')
-  );
+  )
 }
 
 /** Checks if a pathname targets an auth/config endpoint (never cached). */
-function isAuthApi(pathname) {
-  return pathname.startsWith('/auth/') || pathname === '/api/config';
+function isAuthApi (pathname) {
+  return pathname.startsWith('/auth/') || pathname === '/api/config'
 }
 
 /** Network-first strategy: tries network, falls back to cache, then to offline fallback URL. */
-async function networkFirst(request, cacheName, fallbackUrl) {
+async function networkFirst (request, cacheName, fallbackUrl) {
   try {
     if (!isValidHttpUrl(request.url)) {
-      throw new Error('Invalid URL: only http/https URLs are allowed');
+      throw new Error('Invalid URL: only http/https URLs are allowed')
     }
 
     // skipcq: JS-0376 - NOSONAR - URL validated by isValidHttpUrl() guard above
-    const response = await fetch(request);
+    const response = await fetch(request)
     if (response.ok && request.method === 'GET') {
-      const navCache = await caches.open(cacheName);
-      await navCache.put(request, response.clone());
+      const navCache = await caches.open(cacheName)
+      await navCache.put(request, response.clone())
     }
-    return response;
+    return response
   } catch {
     try {
-      const fallbackCache = await caches.open(cacheName);
-      const cached = await fallbackCache.match(request);
-      if (cached) return cached;
+      const fallbackCache = await caches.open(cacheName)
+      const cached = await fallbackCache.match(request)
+      if (cached) return cached
       if (fallbackUrl) {
-        const staticCache = await caches.open(STATIC_CACHE);
-        const fallback = await staticCache.match(fallbackUrl);
-        if (fallback) return fallback;
+        const staticCache = await caches.open(STATIC_CACHE)
+        const fallback = await staticCache.match(fallbackUrl)
+        if (fallback) return fallback
       }
     } catch {
-      console.warn('[SW] cache fallback failed for', request.url);
+      console.warn('[SW] cache fallback failed for', request.url)
     }
     // Graceful degradation instead of throwing
-    return new Response('Service Unavailable', { status: 503 });
+    return new Response('Service Unavailable', { status: 503 })
   }
 }
 
 self.addEventListener('fetch', function (event) {
-  const url = parseUrl(event.request.url);
+  const url = parseUrl(event.request.url)
   if (!url) {
-    return;
+    return
   }
 
   // Skip cross-origin requests — let the browser handle them directly.
-  if (!isSameOrigin(url)) return;
+  if (!isSameOrigin(url)) return
 
   event.respondWith(
     (async function () {
       try {
-        const request = event.request;
+        const request = event.request
 
         // Non-GET requests bypass caching entirely.
-        if (request.method !== 'GET') return fetch(request);
+        if (request.method !== 'GET') return fetch(request)
 
         // Auth/config endpoints carry identity data — never cached.
-        if (isAuthApi(url.pathname)) return fetch(request);
+        if (isAuthApi(url.pathname)) return fetch(request)
 
         if (isProxyApi(url.pathname)) {
           // Only Questionnaire reads are cached (network-first); all other
           // proxy traffic (incl. QuestionnaireResponse) stays network-only.
           if (isCachedProxyApi(url.pathname)) {
-            return await networkFirst(request, NAV_CACHE);
+            return await networkFirst(request, NAV_CACHE)
           }
-          return fetch(request);
+          return fetch(request)
         }
 
         if (request.mode === 'navigate') {
-          return await networkFirst(request, NAV_CACHE, OFFLINE_URL);
+          return await networkFirst(request, NAV_CACHE, OFFLINE_URL)
         }
 
         if (isStaticAsset(url.pathname)) {
-          return await networkFirst(request, STATIC_CACHE);
+          return await networkFirst(request, STATIC_CACHE)
         }
 
-        return await networkFirst(request, NAV_CACHE);
+        return await networkFirst(request, NAV_CACHE)
       } catch (error) {
-        console.warn('[SW] fetch handler error:', error);
-        return new Response('Service Unavailable', { status: 503 });
+        console.warn('[SW] fetch handler error:', error)
+        return new Response('Service Unavailable', { status: 503 })
       }
     })()
-  );
-});
+  )
+})

--- a/public/sw.js
+++ b/public/sw.js
@@ -34,6 +34,13 @@ self.addEventListener('sync', function (event) {
   );
 });
 
+self.addEventListener('message', function (event) {
+  // NOSONAR - self is SW global scope
+  if (event.data && event.data.type === 'SKIP_WAITING') {
+    self.skipWaiting();
+  }
+});
+
 self.addEventListener('activate', function (event) {
   event.waitUntil(
     caches

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,45 +1,45 @@
 /* eslint-disable unicorn/prefer-global-this */
-const SW_VERSION = '2';
-const STATIC_CACHE = `konsulin-static-v${SW_VERSION}`;
-const NAV_CACHE = `konsulin-nav-v${SW_VERSION}`;
-const OFFLINE_URL = '/~offline';
+const SW_VERSION = '2'
+const STATIC_CACHE = `konsulin-static-v${SW_VERSION}`
+const NAV_CACHE = `konsulin-nav-v${SW_VERSION}`
+const OFFLINE_URL = '/~offline'
 
 const PRECACHE_URLS = [
   OFFLINE_URL,
   '/manifest.json',
   '/images/Loading-Time.svg'
-];
+]
 
 self.addEventListener('install', function (event) {
   // NOSONAR - self is SW global scope
   event.waitUntil(
     caches.open(STATIC_CACHE).then(function (cache) {
-      return cache.addAll(PRECACHE_URLS);
+      return cache.addAll(PRECACHE_URLS)
     })
-  );
-  self.skipWaiting(); // NOSONAR - self is SW global scope
-});
+  )
+  self.skipWaiting() // NOSONAR - self is SW global scope
+})
 
 self.addEventListener('sync', function (event) {
   // NOSONAR - self is SW global scope
-  if (event.tag !== 'replay-pending') return;
+  if (event.tag !== 'replay-pending') return
   event.waitUntil(
     self.clients.matchAll().then(function (clients) {
       return Promise.all(
         clients.map(function (client) {
-          return client.postMessage({ type: 'SYNC_REPLAY' });
+          return client.postMessage({ type: 'SYNC_REPLAY' })
         })
-      );
+      )
     })
-  );
-});
+  )
+})
 
 self.addEventListener('message', function (event) {
   // NOSONAR - self is SW global scope
   if (event.data && event.data.type === 'SKIP_WAITING') {
-    self.skipWaiting();
+    self.skipWaiting()
   }
-});
+})
 
 self.addEventListener('activate', function (event) {
   event.waitUntil(
@@ -53,58 +53,58 @@ self.addEventListener('activate', function (event) {
                 key.startsWith('konsulin-') &&
                 key !== STATIC_CACHE &&
                 key !== NAV_CACHE
-              );
+              )
             })
             .map(function (key) {
-              return caches.delete(key);
+              return caches.delete(key)
             })
-        );
+        )
       })
       .then(function () {
-        return self.clients.claim(); // NOSONAR - self is SW global scope
+        return self.clients.claim() // NOSONAR - self is SW global scope
       })
-  );
-});
+  )
+})
 
 /**
  * Parse a URL string safely, returning null on invalid input.
  * Avoids try-catch so SonarCloud doesn't flag unhandled exceptions.
  */
-function parseUrl(url) {
+function parseUrl (url) {
   try {
-    return new URL(url);
+    return new URL(url)
   } catch {
-    return null;
+    return null
   }
 }
 
 /** Checks if a URL uses http or https protocol. */
-function isValidHttpUrl(url) {
-  const parsed = parseUrl(url);
+function isValidHttpUrl (url) {
+  const parsed = parseUrl(url)
   return (
     parsed !== null &&
     (parsed.protocol === 'http:' || parsed.protocol === 'https:')
-  );
+  )
 }
 
 /** Checks if a URL belongs to the same origin. */
-function isSameOrigin(url) {
-  return url.origin === self.location.origin; // NOSONAR - self is SW global scope
+function isSameOrigin (url) {
+  return url.origin === self.location.origin // NOSONAR - self is SW global scope
 }
 
 /** Checks if a pathname is a precacheable static asset. */
-function isStaticAsset(pathname) {
+function isStaticAsset (pathname) {
   return (
     pathname.startsWith('/_next/static/') ||
     pathname.startsWith('/favicon/') ||
     pathname.startsWith('/icons/') ||
     pathname.startsWith('/images/')
-  );
+  )
 }
 
 /** Checks if a pathname targets the proxy API. */
-function isProxyApi(pathname) {
-  return pathname.startsWith('/proxy/');
+function isProxyApi (pathname) {
+  return pathname.startsWith('/proxy/')
 }
 
 /**
@@ -112,92 +112,92 @@ function isProxyApi(pathname) {
  * The negative guard matters: QuestionnaireResponse also starts with
  * Questionnaire but must stay network-only.
  */
-function isCachedProxyApi(pathname) {
+function isCachedProxyApi (pathname) {
   return (
     pathname.startsWith('/proxy/fhir/Questionnaire') &&
     !pathname.startsWith('/proxy/fhir/QuestionnaireResponse')
-  );
+  )
 }
 
 /** Checks if a pathname targets an auth/config endpoint (never cached). */
-function isAuthApi(pathname) {
-  return pathname.startsWith('/auth/') || pathname === '/api/config';
+function isAuthApi (pathname) {
+  return pathname.startsWith('/auth/') || pathname === '/api/config'
 }
 
 /** Network-first strategy: tries network, falls back to cache, then to offline fallback URL. */
-async function networkFirst(request, cacheName, fallbackUrl) {
+async function networkFirst (request, cacheName, fallbackUrl) {
   try {
     if (!isValidHttpUrl(request.url)) {
-      throw new Error('Invalid URL: only http/https URLs are allowed');
+      throw new Error('Invalid URL: only http/https URLs are allowed')
     }
 
     // skipcq: JS-0376 - NOSONAR - URL validated by isValidHttpUrl() guard above
-    const response = await fetch(request);
+    const response = await fetch(request)
     if (response.ok && request.method === 'GET') {
-      const navCache = await caches.open(cacheName);
-      await navCache.put(request, response.clone());
+      const navCache = await caches.open(cacheName)
+      await navCache.put(request, response.clone())
     }
-    return response;
+    return response
   } catch {
     try {
-      const fallbackCache = await caches.open(cacheName);
-      const cached = await fallbackCache.match(request);
-      if (cached) return cached;
+      const fallbackCache = await caches.open(cacheName)
+      const cached = await fallbackCache.match(request)
+      if (cached) return cached
       if (fallbackUrl) {
-        const staticCache = await caches.open(STATIC_CACHE);
-        const fallback = await staticCache.match(fallbackUrl);
-        if (fallback) return fallback;
+        const staticCache = await caches.open(STATIC_CACHE)
+        const fallback = await staticCache.match(fallbackUrl)
+        if (fallback) return fallback
       }
     } catch {
-      console.warn('[SW] cache fallback failed for', request.url);
+      console.warn('[SW] cache fallback failed for', request.url)
     }
     // Graceful degradation instead of throwing
-    return new Response('Service Unavailable', { status: 503 });
+    return new Response('Service Unavailable', { status: 503 })
   }
 }
 
 self.addEventListener('fetch', function (event) {
-  const url = parseUrl(event.request.url);
+  const url = parseUrl(event.request.url)
   if (!url) {
-    return;
+    return
   }
 
   // Skip cross-origin requests — let the browser handle them directly.
-  if (!isSameOrigin(url)) return;
+  if (!isSameOrigin(url)) return
 
   event.respondWith(
     (async function () {
       try {
-        const request = event.request;
+        const request = event.request
 
         // Non-GET requests bypass caching entirely.
-        if (request.method !== 'GET') return fetch(request);
+        if (request.method !== 'GET') return fetch(request)
 
         // Auth/config endpoints carry identity data — never cached.
-        if (isAuthApi(url.pathname)) return fetch(request);
+        if (isAuthApi(url.pathname)) return fetch(request)
 
         if (isProxyApi(url.pathname)) {
           // Only Questionnaire reads are cached (network-first); all other
           // proxy traffic (incl. QuestionnaireResponse) stays network-only.
           if (isCachedProxyApi(url.pathname)) {
-            return await networkFirst(request, NAV_CACHE);
+            return await networkFirst(request, NAV_CACHE)
           }
-          return fetch(request);
+          return fetch(request)
         }
 
         if (request.mode === 'navigate') {
-          return await networkFirst(request, NAV_CACHE, OFFLINE_URL);
+          return await networkFirst(request, NAV_CACHE, OFFLINE_URL)
         }
 
         if (isStaticAsset(url.pathname)) {
-          return await networkFirst(request, STATIC_CACHE);
+          return await networkFirst(request, STATIC_CACHE)
         }
 
-        return await networkFirst(request, NAV_CACHE);
+        return await networkFirst(request, NAV_CACHE)
       } catch (error) {
-        console.warn('[SW] fetch handler error:', error);
-        return new Response('Service Unavailable', { status: 503 });
+        console.warn('[SW] fetch handler error:', error)
+        return new Response('Service Unavailable', { status: 503 })
       }
     })()
-  );
-});
+  )
+})

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,45 +1,46 @@
 /* eslint-disable unicorn/prefer-global-this */
-const SW_VERSION = '2'
-const STATIC_CACHE = `konsulin-static-v${SW_VERSION}`
-const NAV_CACHE = `konsulin-nav-v${SW_VERSION}`
-const OFFLINE_URL = '/~offline'
+const SW_VERSION = '2';
+const STATIC_CACHE = `konsulin-static-v${SW_VERSION}`;
+const NAV_CACHE = `konsulin-nav-v${SW_VERSION}`;
+const OFFLINE_URL = '/~offline';
 
 const PRECACHE_URLS = [
   OFFLINE_URL,
   '/manifest.json',
   '/images/Loading-Time.svg'
-]
+];
 
 self.addEventListener('install', function (event) {
   // NOSONAR - self is SW global scope
   event.waitUntil(
     caches.open(STATIC_CACHE).then(function (cache) {
-      return cache.addAll(PRECACHE_URLS)
+      return cache.addAll(PRECACHE_URLS);
     })
-  )
-  self.skipWaiting() // NOSONAR - self is SW global scope
-})
+  );
+  self.skipWaiting(); // NOSONAR - self is SW global scope
+});
 
 self.addEventListener('sync', function (event) {
   // NOSONAR - self is SW global scope
-  if (event.tag !== 'replay-pending') return
+  if (event.tag !== 'replay-pending') return;
   event.waitUntil(
     self.clients.matchAll().then(function (clients) {
       return Promise.all(
         clients.map(function (client) {
-          return client.postMessage({ type: 'SYNC_REPLAY' })
+          return client.postMessage({ type: 'SYNC_REPLAY' });
         })
-      )
+      );
     })
-  )
-})
+  );
+});
 
 self.addEventListener('message', function (event) {
   // NOSONAR - self is SW global scope
-  if (event.data && event.data.type === 'SKIP_WAITING') {
-    self.skipWaiting()
+  if (event.origin !== self.location.origin) return;
+  if (event.data?.type === 'SKIP_WAITING') {
+    self.skipWaiting();
   }
-})
+});
 
 self.addEventListener('activate', function (event) {
   event.waitUntil(
@@ -53,58 +54,58 @@ self.addEventListener('activate', function (event) {
                 key.startsWith('konsulin-') &&
                 key !== STATIC_CACHE &&
                 key !== NAV_CACHE
-              )
+              );
             })
             .map(function (key) {
-              return caches.delete(key)
+              return caches.delete(key);
             })
-        )
+        );
       })
       .then(function () {
-        return self.clients.claim() // NOSONAR - self is SW global scope
+        return self.clients.claim(); // NOSONAR - self is SW global scope
       })
-  )
-})
+  );
+});
 
 /**
  * Parse a URL string safely, returning null on invalid input.
  * Avoids try-catch so SonarCloud doesn't flag unhandled exceptions.
  */
-function parseUrl (url) {
+function parseUrl(url) {
   try {
-    return new URL(url)
+    return new URL(url);
   } catch {
-    return null
+    return null;
   }
 }
 
 /** Checks if a URL uses http or https protocol. */
-function isValidHttpUrl (url) {
-  const parsed = parseUrl(url)
+function isValidHttpUrl(url) {
+  const parsed = parseUrl(url);
   return (
     parsed !== null &&
     (parsed.protocol === 'http:' || parsed.protocol === 'https:')
-  )
+  );
 }
 
 /** Checks if a URL belongs to the same origin. */
-function isSameOrigin (url) {
-  return url.origin === self.location.origin // NOSONAR - self is SW global scope
+function isSameOrigin(url) {
+  return url.origin === self.location.origin; // NOSONAR - self is SW global scope
 }
 
 /** Checks if a pathname is a precacheable static asset. */
-function isStaticAsset (pathname) {
+function isStaticAsset(pathname) {
   return (
     pathname.startsWith('/_next/static/') ||
     pathname.startsWith('/favicon/') ||
     pathname.startsWith('/icons/') ||
     pathname.startsWith('/images/')
-  )
+  );
 }
 
 /** Checks if a pathname targets the proxy API. */
-function isProxyApi (pathname) {
-  return pathname.startsWith('/proxy/')
+function isProxyApi(pathname) {
+  return pathname.startsWith('/proxy/');
 }
 
 /**
@@ -112,92 +113,92 @@ function isProxyApi (pathname) {
  * The negative guard matters: QuestionnaireResponse also starts with
  * Questionnaire but must stay network-only.
  */
-function isCachedProxyApi (pathname) {
+function isCachedProxyApi(pathname) {
   return (
     pathname.startsWith('/proxy/fhir/Questionnaire') &&
     !pathname.startsWith('/proxy/fhir/QuestionnaireResponse')
-  )
+  );
 }
 
 /** Checks if a pathname targets an auth/config endpoint (never cached). */
-function isAuthApi (pathname) {
-  return pathname.startsWith('/auth/') || pathname === '/api/config'
+function isAuthApi(pathname) {
+  return pathname.startsWith('/auth/') || pathname === '/api/config';
 }
 
 /** Network-first strategy: tries network, falls back to cache, then to offline fallback URL. */
-async function networkFirst (request, cacheName, fallbackUrl) {
+async function networkFirst(request, cacheName, fallbackUrl) {
   try {
     if (!isValidHttpUrl(request.url)) {
-      throw new Error('Invalid URL: only http/https URLs are allowed')
+      throw new Error('Invalid URL: only http/https URLs are allowed');
     }
 
     // skipcq: JS-0376 - NOSONAR - URL validated by isValidHttpUrl() guard above
-    const response = await fetch(request)
+    const response = await fetch(request);
     if (response.ok && request.method === 'GET') {
-      const navCache = await caches.open(cacheName)
-      await navCache.put(request, response.clone())
+      const navCache = await caches.open(cacheName);
+      await navCache.put(request, response.clone());
     }
-    return response
+    return response;
   } catch {
     try {
-      const fallbackCache = await caches.open(cacheName)
-      const cached = await fallbackCache.match(request)
-      if (cached) return cached
+      const fallbackCache = await caches.open(cacheName);
+      const cached = await fallbackCache.match(request);
+      if (cached) return cached;
       if (fallbackUrl) {
-        const staticCache = await caches.open(STATIC_CACHE)
-        const fallback = await staticCache.match(fallbackUrl)
-        if (fallback) return fallback
+        const staticCache = await caches.open(STATIC_CACHE);
+        const fallback = await staticCache.match(fallbackUrl);
+        if (fallback) return fallback;
       }
     } catch {
-      console.warn('[SW] cache fallback failed for', request.url)
+      console.warn('[SW] cache fallback failed for', request.url);
     }
     // Graceful degradation instead of throwing
-    return new Response('Service Unavailable', { status: 503 })
+    return new Response('Service Unavailable', { status: 503 });
   }
 }
 
 self.addEventListener('fetch', function (event) {
-  const url = parseUrl(event.request.url)
+  const url = parseUrl(event.request.url);
   if (!url) {
-    return
+    return;
   }
 
   // Skip cross-origin requests — let the browser handle them directly.
-  if (!isSameOrigin(url)) return
+  if (!isSameOrigin(url)) return;
 
   event.respondWith(
     (async function () {
       try {
-        const request = event.request
+        const request = event.request;
 
         // Non-GET requests bypass caching entirely.
-        if (request.method !== 'GET') return fetch(request)
+        if (request.method !== 'GET') return fetch(request);
 
         // Auth/config endpoints carry identity data — never cached.
-        if (isAuthApi(url.pathname)) return fetch(request)
+        if (isAuthApi(url.pathname)) return fetch(request);
 
         if (isProxyApi(url.pathname)) {
           // Only Questionnaire reads are cached (network-first); all other
           // proxy traffic (incl. QuestionnaireResponse) stays network-only.
           if (isCachedProxyApi(url.pathname)) {
-            return await networkFirst(request, NAV_CACHE)
+            return await networkFirst(request, NAV_CACHE);
           }
-          return fetch(request)
+          return fetch(request);
         }
 
         if (request.mode === 'navigate') {
-          return await networkFirst(request, NAV_CACHE, OFFLINE_URL)
+          return await networkFirst(request, NAV_CACHE, OFFLINE_URL);
         }
 
         if (isStaticAsset(url.pathname)) {
-          return await networkFirst(request, STATIC_CACHE)
+          return await networkFirst(request, STATIC_CACHE);
         }
 
-        return await networkFirst(request, NAV_CACHE)
+        return await networkFirst(request, NAV_CACHE);
       } catch (error) {
-        console.warn('[SW] fetch handler error:', error)
-        return new Response('Service Unavailable', { status: 503 })
+        console.warn('[SW] fetch handler error:', error);
+        return new Response('Service Unavailable', { status: 503 });
       }
     })()
-  )
-})
+  );
+});

--- a/src/__tests__/app-chrome.test.tsx
+++ b/src/__tests__/app-chrome.test.tsx
@@ -7,6 +7,22 @@ vi.mock('@/context/auth/authContext', () => ({
   useAuth: vi.fn()
 }));
 
+vi.mock('@/lib/submission-queue', () => ({
+  pendingCount: vi.fn<() => Promise<number>>().mockResolvedValue(0),
+  replayPendingSubmissions: vi.fn<() => Promise<void>>().mockResolvedValue(),
+  listenForSyncReplay: vi.fn(() => vi.fn())
+}));
+
+vi.mock('@/lib/submission-replay', () => ({
+  registerSubmissionReplayHandlers: vi.fn()
+}));
+
+vi.mock('@/lib/pwa-install', () => ({
+  canInstall: vi.fn(() => false),
+  installPwa: vi.fn(),
+  setupInstallPrompt: vi.fn(() => vi.fn())
+}));
+
 vi.mock('next/navigation', () => ({
   useRouter: vi.fn(),
   usePathname: vi.fn(),

--- a/src/__tests__/test-utils.ts
+++ b/src/__tests__/test-utils.ts
@@ -41,7 +41,10 @@ export function createMockSelf() {
       listenerArr.push(handler);
     }),
     skipWaiting: vi.fn(),
-    clients: { claim: vi.fn() },
+    clients: {
+      claim: vi.fn(),
+      matchAll: vi.fn(() => Promise.resolve([]))
+    },
     location: { origin: 'http://konsulin.care' }
   };
 }
@@ -128,6 +131,17 @@ export function fireFetch(
   const event = createMockEvent({ request });
   const handler = mockSelf.handlers.fetch[0];
   expect(handler, 'fetch handler must be registered').toBeDefined();
+  handler(event);
+  return event;
+}
+
+/**
+ *
+ */
+export function fireSync(mockSelf: MockSelf, tag: string) {
+  const event = createMockEvent({ tag });
+  const handler = mockSelf.handlers.sync[0];
+  expect(handler, 'sync handler must be registered').toBeDefined();
   handler(event);
   return event;
 }

--- a/src/app/__tests__/layout.test.tsx
+++ b/src/app/__tests__/layout.test.tsx
@@ -58,6 +58,22 @@ vi.mock('nextjs-toploader', () => ({
   default: () => <div data-testid='next-top-loader' />
 }));
 
+vi.mock('@/lib/submission-queue', () => ({
+  pendingCount: vi.fn<() => Promise<number>>().mockResolvedValue(0),
+  replayPendingSubmissions: vi.fn<() => Promise<void>>().mockResolvedValue(),
+  listenForSyncReplay: vi.fn(() => vi.fn())
+}));
+
+vi.mock('@/lib/submission-replay', () => ({
+  registerSubmissionReplayHandlers: vi.fn()
+}));
+
+vi.mock('@/lib/pwa-install', () => ({
+  canInstall: vi.fn(() => false),
+  installPwa: vi.fn(),
+  setupInstallPrompt: vi.fn(() => vi.fn())
+}));
+
 vi.mock('react-toastify', () => ({
   ToastContainer: () => <div data-testid='toast-container' />
 }));

--- a/src/components/app-chrome.tsx
+++ b/src/components/app-chrome.tsx
@@ -1,5 +1,6 @@
 import ProfileCompletenessModal from '@/components/general/profile-completeness-modal';
 import RouteResponseCleaner from '@/components/general/route-response-cleaner';
+import PendingSubmissionsBanner from '@/components/pwa/pending-submissions';
 import QuickActionFab from '@/components/quick-action-fab';
 import { FabProvider } from '@/context/fabContext';
 import { resolveCjsDefaultExport } from '@/lib/lazy-component';
@@ -57,6 +58,7 @@ export default function AppChrome({
       <ToastContainer {...toastConfig} />
       <ProfileCompletenessModal />
       <AppProviders>
+        <PendingSubmissionsBanner />
         <PageContent>{children}</PageContent>
         <QuickActionFab />
       </AppProviders>

--- a/src/components/app-chrome.tsx
+++ b/src/components/app-chrome.tsx
@@ -5,6 +5,7 @@ import PendingSubmissionsBanner from '@/components/pwa/pending-submissions';
 import QuickActionFab from '@/components/quick-action-fab';
 import { FabProvider } from '@/context/fabContext';
 import { resolveCjsDefaultExport } from '@/lib/lazy-component';
+import SwUpdateDetector from '@/lib/sw-update';
 import dynamic from 'next/dynamic';
 import { Suspense, type ComponentType, type ReactNode } from 'react';
 import { ToastContainer, ToastContainerProps } from 'react-toastify';
@@ -58,6 +59,7 @@ export default function AppChrome({
       </Suspense>
       <ToastContainer {...toastConfig} />
       <ProfileCompletenessModal />
+      <SwUpdateDetector />
       <AppProviders>
         <PendingSubmissionsBanner />
         <PageContent>{children}</PageContent>

--- a/src/components/app-chrome.tsx
+++ b/src/components/app-chrome.tsx
@@ -1,5 +1,6 @@
 import ProfileCompletenessModal from '@/components/general/profile-completeness-modal';
 import RouteResponseCleaner from '@/components/general/route-response-cleaner';
+import ConnectivityIndicator from '@/components/pwa/connectivity-indicator';
 import InstallButton from '@/components/pwa/install-button';
 import PendingSubmissionsBanner from '@/components/pwa/pending-submissions';
 import QuickActionFab from '@/components/quick-action-fab';
@@ -61,6 +62,7 @@ export default function AppChrome({
       <ProfileCompletenessModal />
       <SwUpdateDetector />
       <AppProviders>
+        <ConnectivityIndicator />
         <PendingSubmissionsBanner />
         <PageContent>{children}</PageContent>
         <InstallButton />

--- a/src/components/app-chrome.tsx
+++ b/src/components/app-chrome.tsx
@@ -1,5 +1,6 @@
 import ProfileCompletenessModal from '@/components/general/profile-completeness-modal';
 import RouteResponseCleaner from '@/components/general/route-response-cleaner';
+import InstallButton from '@/components/pwa/install-button';
 import PendingSubmissionsBanner from '@/components/pwa/pending-submissions';
 import QuickActionFab from '@/components/quick-action-fab';
 import { FabProvider } from '@/context/fabContext';
@@ -60,6 +61,7 @@ export default function AppChrome({
       <AppProviders>
         <PendingSubmissionsBanner />
         <PageContent>{children}</PageContent>
+        <InstallButton />
         <QuickActionFab />
       </AppProviders>
     </>

--- a/src/components/general/query-provider.tsx
+++ b/src/components/general/query-provider.tsx
@@ -3,6 +3,13 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { useRef } from 'react';
 
+let appQueryClient: QueryClient | null = null;
+
+/** Returns the app-wide QueryClient, or null before the provider mounts. */
+export function getAppQueryClient(): QueryClient | null {
+  return appQueryClient;
+}
+
 /**
  *
  */
@@ -21,6 +28,7 @@ export default function QueryProvider({
         }
       }
     });
+    appQueryClient = queryClientRef.current;
   }
 
   return (

--- a/src/components/pwa/__tests__/connectivity-indicator.test.tsx
+++ b/src/components/pwa/__tests__/connectivity-indicator.test.tsx
@@ -1,0 +1,40 @@
+import { getStatus, subscribe } from '@/lib/connectivity';
+import { render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import ConnectivityIndicator from '../connectivity-indicator';
+
+vi.mock('@/lib/connectivity', () => ({
+  getStatus: vi.fn(),
+  initConnectivity: vi.fn(),
+  subscribe: vi.fn(() => vi.fn())
+}));
+
+describe('ConnectivityIndicator', () => {
+  beforeEach(() => {
+    vi.mocked(getStatus).mockReturnValue('stable');
+    vi.mocked(subscribe).mockReturnValue(vi.fn());
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders nothing when the connection is stable', () => {
+    render(<ConnectivityIndicator />);
+    expect(screen.queryByRole('status')).toBeNull();
+  });
+
+  it('shows a subtle retrying bar when the connection is unstable', () => {
+    vi.mocked(getStatus).mockReturnValue('unstable');
+    render(<ConnectivityIndicator />);
+    expect(screen.getByRole('status')).toHaveTextContent(
+      /connection unstable/i
+    );
+  });
+
+  it('shows an offline message when fully offline', () => {
+    vi.mocked(getStatus).mockReturnValue('offline');
+    render(<ConnectivityIndicator />);
+    expect(screen.getByRole('status')).toHaveTextContent(/offline/i);
+  });
+});

--- a/src/components/pwa/__tests__/connectivity-indicator.test.tsx
+++ b/src/components/pwa/__tests__/connectivity-indicator.test.tsx
@@ -37,4 +37,10 @@ describe('ConnectivityIndicator', () => {
     render(<ConnectivityIndicator />);
     expect(screen.getByRole('status')).toHaveTextContent(/offline/i);
   });
+
+  it('renders the status region as an <output> element', () => {
+    vi.mocked(getStatus).mockReturnValue('offline');
+    const { container } = render(<ConnectivityIndicator />);
+    expect(container.querySelector('output')).not.toBeNull();
+  });
 });

--- a/src/components/pwa/__tests__/install-button.test.tsx
+++ b/src/components/pwa/__tests__/install-button.test.tsx
@@ -1,0 +1,67 @@
+import { canInstall, installPwa } from '@/lib/pwa-install';
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import InstallButton from '../install-button';
+
+let mockOnChangeCallback: (() => void) | undefined;
+
+vi.mock('@/lib/pwa-install', () => ({
+  canInstall: vi.fn(),
+  installPwa: vi.fn(),
+  setupInstallPrompt: vi.fn((callback: () => void) => {
+    mockOnChangeCallback = callback;
+    return vi.fn();
+  })
+}));
+
+describe('InstallButton', () => {
+  beforeEach(() => {
+    mockOnChangeCallback = undefined;
+    vi.mocked(canInstall).mockReturnValue(false);
+  });
+
+  it('renders nothing before the install prompt is available', () => {
+    const { container } = render(<InstallButton />);
+
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('shows the install button when the prompt becomes available', () => {
+    vi.mocked(canInstall).mockReturnValue(true);
+    render(<InstallButton />);
+
+    act(() => {
+      mockOnChangeCallback?.();
+    });
+
+    expect(screen.getByRole('button', { name: /install app/i })).toBeTruthy();
+  });
+
+  it('hides the button after the app is installed', () => {
+    vi.mocked(canInstall).mockReturnValue(true);
+    render(<InstallButton />);
+    act(() => {
+      mockOnChangeCallback?.();
+    });
+    expect(screen.getByRole('button', { name: /install app/i })).toBeTruthy();
+
+    vi.mocked(canInstall).mockReturnValue(false);
+    act(() => {
+      mockOnChangeCallback?.();
+    });
+
+    expect(screen.queryByRole('button', { name: /install app/i })).toBeNull();
+  });
+
+  it('triggers the install prompt on click', () => {
+    vi.mocked(canInstall).mockReturnValue(true);
+    render(<InstallButton />);
+    act(() => {
+      mockOnChangeCallback?.();
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /install app/i }));
+
+    expect(installPwa).toHaveBeenCalled();
+  });
+});

--- a/src/components/pwa/__tests__/pending-submissions.test.tsx
+++ b/src/components/pwa/__tests__/pending-submissions.test.tsx
@@ -1,0 +1,82 @@
+import {
+  listenForSyncReplay,
+  pendingCount,
+  replayPendingSubmissions
+} from '@/lib/submission-queue';
+import { registerSubmissionReplayHandlers } from '@/lib/submission-replay';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import PendingSubmissionsBanner from '../pending-submissions';
+
+vi.mock('@/lib/submission-queue', () => ({
+  pendingCount: vi.fn(),
+  replayPendingSubmissions: vi.fn(),
+  listenForSyncReplay: vi.fn(() => vi.fn())
+}));
+
+vi.mock('@/lib/submission-replay', () => ({
+  registerSubmissionReplayHandlers: vi.fn()
+}));
+
+describe('PendingSubmissionsBanner', () => {
+  beforeEach(() => {
+    vi.mocked(pendingCount).mockResolvedValue(2);
+    vi.mocked(replayPendingSubmissions).mockResolvedValue();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('shows the pending count and a sync button when submissions are queued', async () => {
+    render(<PendingSubmissionsBanner />);
+
+    expect(await screen.findByText(/2/)).toBeTruthy();
+    expect(screen.getByRole('button', { name: /sync now/i })).toBeTruthy();
+  });
+
+  it('renders nothing when the queue is empty', async () => {
+    vi.mocked(pendingCount).mockResolvedValue(0);
+
+    const { container } = render(<PendingSubmissionsBanner />);
+
+    await waitFor(() => expect(pendingCount).toHaveBeenCalled());
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('replays the queue when Sync now is clicked and refreshes the count', async () => {
+    render(<PendingSubmissionsBanner />);
+    await screen.findByText(/2/);
+
+    vi.mocked(pendingCount).mockResolvedValue(0);
+    fireEvent.click(screen.getByRole('button', { name: /sync now/i }));
+
+    // Called once on mount (page-load replay) and once on click.
+    await waitFor(() =>
+      expect(replayPendingSubmissions).toHaveBeenCalledTimes(2)
+    );
+    await waitFor(() =>
+      expect(screen.queryByRole('button', { name: /sync now/i })).toBeNull()
+    );
+  });
+
+  it('replays the queue when the browser comes online', async () => {
+    render(<PendingSubmissionsBanner />);
+    await screen.findByText(/2/);
+
+    window.dispatchEvent(new Event('online'));
+
+    // Called once on mount and once for the online event.
+    await waitFor(() =>
+      expect(replayPendingSubmissions).toHaveBeenCalledTimes(2)
+    );
+  });
+
+  it('registers replay handlers and the SW message listener on mount', async () => {
+    render(<PendingSubmissionsBanner />);
+
+    await screen.findByText(/2/);
+    expect(registerSubmissionReplayHandlers).toHaveBeenCalled();
+    expect(listenForSyncReplay).toHaveBeenCalled();
+  });
+});

--- a/src/components/pwa/__tests__/pending-submissions.test.tsx
+++ b/src/components/pwa/__tests__/pending-submissions.test.tsx
@@ -35,6 +35,12 @@ describe('PendingSubmissionsBanner', () => {
     expect(screen.getByRole('button', { name: /sync now/i })).toBeTruthy();
   });
 
+  it('renders the banner as an <output> element', async () => {
+    const { container } = render(<PendingSubmissionsBanner />);
+    await screen.findByText(/2/);
+    expect(container.querySelector('output')).not.toBeNull();
+  });
+
   it('renders nothing when the queue is empty', async () => {
     vi.mocked(pendingCount).mockResolvedValue(0);
 

--- a/src/components/pwa/connectivity-indicator.tsx
+++ b/src/components/pwa/connectivity-indicator.tsx
@@ -28,11 +28,8 @@ export default function ConnectivityIndicator() {
       : 'Connection unstable — retrying…';
 
   return (
-    <div
-      role='status'
-      className='flex items-center justify-center border-b border-neutral-200 bg-neutral-50 px-4 py-2 text-center text-xs text-neutral-500'
-    >
+    <output className='flex items-center justify-center border-b border-neutral-200 bg-neutral-50 px-4 py-2 text-center text-xs text-neutral-500'>
       {message}
-    </div>
+    </output>
   );
 }

--- a/src/components/pwa/connectivity-indicator.tsx
+++ b/src/components/pwa/connectivity-indicator.tsx
@@ -1,0 +1,38 @@
+'use client';
+
+import {
+  getStatus,
+  initConnectivity,
+  subscribe,
+  type ConnectivityStatus
+} from '@/lib/connectivity';
+import { useEffect, useState } from 'react';
+
+/**
+ * Subtle bar shown while the connection is flaky or offline.
+ * Renders nothing when the connection is stable.
+ */
+export default function ConnectivityIndicator() {
+  const [status, setStatus] = useState<ConnectivityStatus>(() => getStatus());
+
+  useEffect(() => {
+    initConnectivity();
+    return subscribe(setStatus);
+  }, []);
+
+  if (status === 'stable') return null;
+
+  const message =
+    status === 'offline'
+      ? 'You are offline'
+      : 'Connection unstable — retrying…';
+
+  return (
+    <div
+      role='status'
+      className='flex items-center justify-center border-b border-neutral-200 bg-neutral-50 px-4 py-2 text-center text-xs text-neutral-500'
+    >
+      {message}
+    </div>
+  );
+}

--- a/src/components/pwa/install-button.tsx
+++ b/src/components/pwa/install-button.tsx
@@ -8,7 +8,9 @@ export default function InstallButton() {
   const [visible, setVisible] = useState(false);
 
   useEffect(() => {
-    return setupInstallPrompt(() => setVisible(canInstall()));
+    return setupInstallPrompt(() => {
+      setVisible(canInstall());
+    });
   }, []);
 
   /** Shows the deferred browser install prompt. */

--- a/src/components/pwa/install-button.tsx
+++ b/src/components/pwa/install-button.tsx
@@ -11,12 +11,18 @@ export default function InstallButton() {
     return setupInstallPrompt(() => setVisible(canInstall()));
   }, []);
 
+  /** Shows the deferred browser install prompt. */
+  const handleInstallClick = () => {
+    // skipcq: JS-0098 - fire-and-forget install prompt
+    void installPwa();
+  };
+
   if (!visible) return null;
 
   return (
     <button
       type='button'
-      onClick={() => void installPwa()}
+      onClick={handleInstallClick}
       className='cursor-pointer font-semibold text-teal-600 underline'
     >
       Install app

--- a/src/components/pwa/install-button.tsx
+++ b/src/components/pwa/install-button.tsx
@@ -1,0 +1,25 @@
+'use client';
+
+import { canInstall, installPwa, setupInstallPrompt } from '@/lib/pwa-install';
+import { useEffect, useState } from 'react';
+
+/** Offers PWA installation when the browser exposes an install prompt. */
+export default function InstallButton() {
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    return setupInstallPrompt(() => setVisible(canInstall()));
+  }, []);
+
+  if (!visible) return null;
+
+  return (
+    <button
+      type='button'
+      onClick={() => void installPwa()}
+      className='cursor-pointer font-semibold text-teal-600 underline'
+    >
+      Install app
+    </button>
+  );
+}

--- a/src/components/pwa/pending-submissions.tsx
+++ b/src/components/pwa/pending-submissions.tsx
@@ -32,22 +32,27 @@ export function usePendingSubmissions(): PendingSubmissionsState {
     const unsubscribe = listenForSyncReplay();
 
     let cancelled = false;
+
+    /** Refreshes the queued count unless the effect was cleaned up. */
     const refresh = async () => {
       const next = await pendingCount();
       if (!cancelled) setCount(next);
     };
 
-    // Page-load replay: flush anything queued while the app was offline.
-    void (async () => {
+    /** Replays queued submissions, then refreshes the count. */
+    const replay = async () => {
       await replayPendingSubmissions();
       await refresh();
-    })();
+    };
 
+    // Page-load replay: flush anything queued while the app was offline.
+    // skipcq: JS-0098 - fire-and-forget replay on page load
+    void replay();
+
+    /** Fires a replay when the browser comes back online. */
     const onOnline = () => {
-      void (async () => {
-        await replayPendingSubmissions();
-        await refresh();
-      })();
+      // skipcq: JS-0098 - fire-and-forget replay on reconnect
+      void replay();
     };
     window.addEventListener('online', onOnline);
 
@@ -67,6 +72,12 @@ export default function PendingSubmissionsBanner() {
 
   if (count === 0) return null;
 
+  /** Triggers a manual sync of queued submissions. */
+  const handleSyncNow = () => {
+    // skipcq: JS-0098 - fire-and-forget manual sync
+    void syncNow();
+  };
+
   return (
     <div
       role='status'
@@ -77,7 +88,7 @@ export default function PendingSubmissionsBanner() {
       </span>
       <button
         type='button'
-        onClick={() => void syncNow()}
+        onClick={handleSyncNow}
         className='cursor-pointer font-semibold text-teal-600 underline'
       >
         Sync now

--- a/src/components/pwa/pending-submissions.tsx
+++ b/src/components/pwa/pending-submissions.tsx
@@ -79,10 +79,7 @@ export default function PendingSubmissionsBanner() {
   };
 
   return (
-    <div
-      role='status'
-      className='flex items-center justify-between gap-2 border-b border-neutral-200 bg-amber-50 px-4 py-2 text-sm'
-    >
+    <output className='flex items-center justify-between gap-2 border-b border-neutral-200 bg-amber-50 px-4 py-2 text-sm'>
       <span>
         {count} submission{count === 1 ? '' : 's'} waiting to sync
       </span>
@@ -93,6 +90,6 @@ export default function PendingSubmissionsBanner() {
       >
         Sync now
       </button>
-    </div>
+    </output>
   );
 }

--- a/src/components/pwa/pending-submissions.tsx
+++ b/src/components/pwa/pending-submissions.tsx
@@ -1,0 +1,87 @@
+'use client';
+
+import {
+  listenForSyncReplay,
+  pendingCount,
+  replayPendingSubmissions
+} from '@/lib/submission-queue';
+import { registerSubmissionReplayHandlers } from '@/lib/submission-replay';
+import { useCallback, useEffect, useState } from 'react';
+
+/** Number of queued submissions and a manual retry trigger. */
+export type PendingSubmissionsState = {
+  count: number;
+  syncNow: () => Promise<void>;
+};
+
+/**
+ * Tracks queued offline submissions. Registers replay handlers and the
+ * SW message listener once, replays on page load and on the online
+ * event, and exposes a manual retry.
+ */
+export function usePendingSubmissions(): PendingSubmissionsState {
+  const [count, setCount] = useState(0);
+
+  const syncNow = useCallback(async () => {
+    await replayPendingSubmissions();
+    setCount(await pendingCount());
+  }, []);
+
+  useEffect(() => {
+    registerSubmissionReplayHandlers();
+    const unsubscribe = listenForSyncReplay();
+
+    let cancelled = false;
+    const refresh = async () => {
+      const next = await pendingCount();
+      if (!cancelled) setCount(next);
+    };
+
+    // Page-load replay: flush anything queued while the app was offline.
+    void (async () => {
+      await replayPendingSubmissions();
+      await refresh();
+    })();
+
+    const onOnline = () => {
+      void (async () => {
+        await replayPendingSubmissions();
+        await refresh();
+      })();
+    };
+    window.addEventListener('online', onOnline);
+
+    return () => {
+      cancelled = true;
+      window.removeEventListener('online', onOnline);
+      unsubscribe();
+    };
+  }, []);
+
+  return { count, syncNow };
+}
+
+/** Banner showing queued submissions with a manual sync button. */
+export default function PendingSubmissionsBanner() {
+  const { count, syncNow } = usePendingSubmissions();
+
+  if (count === 0) return null;
+
+  return (
+    <div
+      role='status'
+      className='flex items-center justify-between gap-2 border-b border-neutral-200 bg-amber-50 px-4 py-2 text-sm'
+    >
+      <span>
+        {count} submission{count === 1 ? '' : 's'} waiting to sync
+      </span>
+      <button
+        type='button'
+        onClick={() => void syncNow()}
+        className='cursor-pointer font-semibold text-teal-600 underline'
+      >
+        Sync now
+      </button>
+    </div>
+  );
+}

--- a/src/lib/__tests__/api-retry.test.ts
+++ b/src/lib/__tests__/api-retry.test.ts
@@ -1,0 +1,117 @@
+import {
+  BASE_RETRY_DELAY_MS,
+  MAX_JITTER_MS,
+  MAX_RETRY_COUNT,
+  getRetryDelayMs,
+  shouldRetryRequest
+} from '@/lib/api-retry';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+/** Build an axios-style error with the given shape. */
+function makeError(overrides: Record<string, unknown> = {}): unknown {
+  return {
+    code: undefined,
+    response: undefined,
+    ...overrides
+  };
+}
+
+const GET_CONFIG = { method: 'GET' };
+const POST_CONFIG = { method: 'POST' };
+
+describe('shouldRetryRequest', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('retries GET requests that fail with a network error (no response)', () => {
+    expect(shouldRetryRequest(makeError(), GET_CONFIG, 0)).toBe(true);
+  });
+
+  it('retries GET requests that fail with ERR_NETWORK', () => {
+    const error = makeError({ code: 'ERR_NETWORK' });
+    expect(shouldRetryRequest(error, GET_CONFIG, 0)).toBe(true);
+  });
+
+  it('retries GET requests that fail with a 5xx status', () => {
+    const error = makeError({ response: { status: 503 } });
+    expect(shouldRetryRequest(error, GET_CONFIG, 0)).toBe(true);
+    expect(
+      shouldRetryRequest(
+        makeError({ response: { status: 500 } }),
+        GET_CONFIG,
+        1
+      )
+    ).toBe(true);
+  });
+
+  it('never retries non-GET requests, even on network errors', () => {
+    expect(shouldRetryRequest(makeError(), POST_CONFIG, 0)).toBe(false);
+    expect(
+      shouldRetryRequest(makeError({ code: 'ERR_NETWORK' }), POST_CONFIG, 0)
+    ).toBe(false);
+  });
+
+  it('never retries 4xx statuses', () => {
+    for (const status of [400, 401, 403, 404, 409, 422]) {
+      const error = makeError({ response: { status } });
+      expect(shouldRetryRequest(error, GET_CONFIG, 0)).toBe(false);
+    }
+  });
+
+  it('never retries once the retry budget is exhausted', () => {
+    expect(shouldRetryRequest(makeError(), GET_CONFIG, MAX_RETRY_COUNT)).toBe(
+      false
+    );
+    expect(
+      shouldRetryRequest(makeError(), GET_CONFIG, MAX_RETRY_COUNT + 1)
+    ).toBe(false);
+  });
+
+  it('retries up to MAX_RETRY_COUNT times', () => {
+    expect(
+      shouldRetryRequest(makeError(), GET_CONFIG, MAX_RETRY_COUNT - 1)
+    ).toBe(true);
+  });
+
+  it('does not retry when the request config is missing', () => {
+    expect(shouldRetryRequest(makeError(), undefined, 0)).toBe(false);
+  });
+
+  it('does not retry when the method is unknown', () => {
+    expect(shouldRetryRequest(makeError(), {}, 0)).toBe(false);
+  });
+});
+
+describe('getRetryDelayMs', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('returns the base delay for the first attempt without jitter', () => {
+    vi.spyOn(Math, 'random').mockReturnValue(0);
+    expect(getRetryDelayMs(0)).toBe(BASE_RETRY_DELAY_MS);
+  });
+
+  it('exponential backoff: doubles the base delay each attempt', () => {
+    vi.spyOn(Math, 'random').mockReturnValue(0);
+    expect(getRetryDelayMs(1)).toBe(BASE_RETRY_DELAY_MS * 2);
+    expect(getRetryDelayMs(2)).toBe(BASE_RETRY_DELAY_MS * 4);
+  });
+
+  it('is monotonic across attempts', () => {
+    for (let attempt = 0; attempt < 4; attempt++) {
+      const current = getRetryDelayMs(attempt);
+      const next = getRetryDelayMs(attempt + 1);
+      expect(next).toBeGreaterThan(current);
+    }
+  });
+
+  it('is bounded by base delay plus max jitter', () => {
+    vi.spyOn(Math, 'random').mockReturnValue(0.9999);
+    expect(getRetryDelayMs(0)).toBeLessThanOrEqual(
+      BASE_RETRY_DELAY_MS + MAX_JITTER_MS
+    );
+    expect(getRetryDelayMs(0)).toBeGreaterThanOrEqual(BASE_RETRY_DELAY_MS);
+  });
+});

--- a/src/lib/__tests__/api-retry.test.ts
+++ b/src/lib/__tests__/api-retry.test.ts
@@ -19,6 +19,12 @@ function makeError(overrides: Record<string, unknown> = {}): unknown {
 const GET_CONFIG = { method: 'GET' };
 const POST_CONFIG = { method: 'POST' };
 
+/** Mocks crypto.getRandomValues to return a fixed 32-bit fraction. */
+function mockRandomValue(fraction: number): void {
+  const value = Math.floor(fraction * 2 ** 32);
+  vi.spyOn(crypto, 'getRandomValues').mockReturnValue(new Uint32Array([value]));
+}
+
 describe('shouldRetryRequest', () => {
   afterEach(() => {
     vi.restoreAllMocks();
@@ -89,12 +95,12 @@ describe('getRetryDelayMs', () => {
   });
 
   it('returns the base delay for the first attempt without jitter', () => {
-    vi.spyOn(Math, 'random').mockReturnValue(0);
+    mockRandomValue(0);
     expect(getRetryDelayMs(0)).toBe(BASE_RETRY_DELAY_MS);
   });
 
   it('exponential backoff: doubles the base delay each attempt', () => {
-    vi.spyOn(Math, 'random').mockReturnValue(0);
+    mockRandomValue(0);
     expect(getRetryDelayMs(1)).toBe(BASE_RETRY_DELAY_MS * 2);
     expect(getRetryDelayMs(2)).toBe(BASE_RETRY_DELAY_MS * 4);
   });
@@ -108,7 +114,7 @@ describe('getRetryDelayMs', () => {
   });
 
   it('is bounded by base delay plus max jitter', () => {
-    vi.spyOn(Math, 'random').mockReturnValue(0.9999);
+    mockRandomValue(0.9999);
     expect(getRetryDelayMs(0)).toBeLessThanOrEqual(
       BASE_RETRY_DELAY_MS + MAX_JITTER_MS
     );

--- a/src/lib/__tests__/connectivity.test.ts
+++ b/src/lib/__tests__/connectivity.test.ts
@@ -1,0 +1,102 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+type ConnectivityModule = typeof import('@/lib/connectivity');
+
+/** Re-imports the module so each test starts with fresh internal state. */
+async function freshModule(): Promise<ConnectivityModule> {
+  vi.resetModules();
+  return import('@/lib/connectivity');
+}
+
+describe('connectivity', () => {
+  let connectivity: ConnectivityModule;
+
+  beforeEach(async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1_000_000);
+    connectivity = await freshModule();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('starts as stable', () => {
+    expect(connectivity.getStatus()).toBe('stable');
+  });
+
+  it('stays stable after a single failure', () => {
+    connectivity.reportRequestOutcome(false);
+    expect(connectivity.getStatus()).toBe('stable');
+  });
+
+  it('turns unstable after a burst of failures', () => {
+    connectivity.reportRequestOutcome(false);
+    connectivity.reportRequestOutcome(false);
+    expect(connectivity.getStatus()).toBe('unstable');
+  });
+
+  it('recovers to stable after a success clears the failure window', () => {
+    connectivity.reportRequestOutcome(false);
+    connectivity.reportRequestOutcome(false);
+    expect(connectivity.getStatus()).toBe('unstable');
+
+    connectivity.reportRequestOutcome(true);
+    expect(connectivity.getStatus()).toBe('stable');
+  });
+
+  it('expires old failures after the 30s window elapses', () => {
+    connectivity.reportRequestOutcome(false);
+    connectivity.reportRequestOutcome(false);
+    expect(connectivity.getStatus()).toBe('unstable');
+
+    vi.setSystemTime(1_000_000 + 31_000);
+    expect(connectivity.getStatus()).toBe('stable');
+  });
+
+  it('reports offline when navigator.onLine is false', () => {
+    Object.defineProperty(navigator, 'onLine', {
+      configurable: true,
+      get: () => false
+    });
+    try {
+      expect(connectivity.getStatus()).toBe('offline');
+    } finally {
+      // jsdom defines onLine on the prototype; deleting the own property
+      // restores the prototype getter for subsequent tests.
+      Reflect.deleteProperty(navigator, 'onLine');
+    }
+  });
+
+  it('flips to offline on a window offline event and back on online', () => {
+    connectivity.initConnectivity();
+
+    window.dispatchEvent(new Event('offline'));
+    expect(connectivity.getStatus()).toBe('offline');
+
+    window.dispatchEvent(new Event('online'));
+    expect(connectivity.getStatus()).toBe('stable');
+  });
+
+  it('notifies subscribers on status changes', () => {
+    const listener = vi.fn();
+    connectivity.subscribe(listener);
+
+    connectivity.reportRequestOutcome(false);
+    connectivity.reportRequestOutcome(false);
+
+    expect(listener).toHaveBeenLastCalledWith('unstable');
+  });
+
+  it('unsubscribe stops notifications', () => {
+    const listener = vi.fn();
+    const unsubscribe = connectivity.subscribe(listener);
+    unsubscribe();
+
+    connectivity.reportRequestOutcome(false);
+    connectivity.reportRequestOutcome(false);
+
+    expect(listener).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/__tests__/connectivity.test.ts
+++ b/src/lib/__tests__/connectivity.test.ts
@@ -3,7 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 type ConnectivityModule = typeof import('@/lib/connectivity');
 
 /** Re-imports the module so each test starts with fresh internal state. */
-async function freshModule(): Promise<ConnectivityModule> {
+function freshModule(): Promise<ConnectivityModule> {
   vi.resetModules();
   return import('@/lib/connectivity');
 }

--- a/src/lib/__tests__/indexeddb.test.ts
+++ b/src/lib/__tests__/indexeddb.test.ts
@@ -37,6 +37,76 @@ function createMockRequest(result?: IDBDatabase, error?: DOMException) {
   return request;
 }
 
+describe('schema v3', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+  });
+
+  it('exports DB_VERSION 3', async () => {
+    const mod = await import('@/lib/indexeddb');
+    expect(mod.DB_VERSION).toBe(3);
+  });
+
+  it('declares the pending_submissions store with id keyPath', async () => {
+    const mod = await import('@/lib/indexeddb');
+    expect(mod.STORES.pendingSubmissions).toBe('pending_submissions');
+    const schema = mod.STORE_SCHEMAS.find(
+      (s: { name: string }) => s.name === 'pending_submissions'
+    );
+    expect(schema).toBeDefined();
+    expect(schema.keyPath).toBe('id');
+  });
+
+  it('creates only the pending_submissions store during v2 -> v3 upgrade', async () => {
+    const mod = await import('@/lib/indexeddb');
+    const v2Stores = new Set([
+      'guest_sessions',
+      'assessment_drafts',
+      'soap_drafts',
+      'service_requests',
+      'temp_booking',
+      'ui_preferences',
+      'navigation_state',
+      'user_profile'
+    ]);
+    const createObjectStore = vi.fn();
+    const mockDb = {
+      name: 'konsulin',
+      version: 3,
+      objectStoreNames: {
+        contains: vi.fn((name: string) => v2Stores.has(name))
+      },
+      createObjectStore,
+      addEventListener: vi.fn(),
+      close: vi.fn(),
+      onclose: null,
+      onversionchange: null
+    };
+
+    const request = createMockRequest(mockDb as unknown as IDBDatabase);
+    mockIndexedDB.open.mockImplementation(() => {
+      setTimeout(() => {
+        if (request.onupgradeneeded) {
+          triggerEvent(request.onupgradeneeded, { target: request });
+        }
+        if (request.onsuccess) {
+          triggerEvent(request.onsuccess, { target: request });
+        }
+      }, 0);
+      return request;
+    });
+
+    await mod.openDB();
+
+    // Existing v2 stores are left untouched; only the new store is created.
+    expect(createObjectStore).toHaveBeenCalledTimes(1);
+    expect(createObjectStore).toHaveBeenCalledWith('pending_submissions', {
+      keyPath: 'id'
+    });
+  });
+});
+
 describe('openDB', () => {
   beforeEach(async () => {
     vi.clearAllMocks();
@@ -52,7 +122,7 @@ describe('openDB', () => {
   it('opens DB with a single indexedDB.open call in normal case', async () => {
     const mockDb = {
       name: 'konsulin',
-      version: 2,
+      version: 3,
       objectStoreNames: { contains: vi.fn().mockReturnValue(true) },
       addEventListener: vi.fn(),
       close: vi.fn(),
@@ -77,7 +147,7 @@ describe('openDB', () => {
     expect(db).toBe(mockDb);
     // Normal path: directly opens with DB_VERSION, no discovery
     expect(mockIndexedDB.open).toHaveBeenCalledTimes(1);
-    expect(mockIndexedDB.open).toHaveBeenCalledWith('konsulin', 2);
+    expect(mockIndexedDB.open).toHaveBeenCalledWith('konsulin', 3);
   });
 
   it('reuses the same DB promise on subsequent calls', async () => {
@@ -136,7 +206,7 @@ describe('openDB', () => {
           }
         }, 0);
       } else {
-        req.result = mockDb as unknown as IDBDatabase;
+        req.result = mockDb;
         setTimeout(() => {
           if (req.onsuccess) {
             triggerEvent(req.onsuccess, { target: req });
@@ -174,7 +244,7 @@ describe('openDB', () => {
     };
 
     const versionError = new DOMException(
-      'The requested version (2) is less than the existing version (5).',
+      'The requested version (3) is less than the existing version (5).',
       'VersionError'
     );
 
@@ -183,7 +253,7 @@ describe('openDB', () => {
       openCount++;
       const req = createMockRequest();
 
-      if (openCount === 1 && version === 2) {
+      if (openCount === 1 && version === 3) {
         // First attempt: VersionError
         req.error = versionError;
         setTimeout(() => {

--- a/src/lib/__tests__/pwa-install.test.ts
+++ b/src/lib/__tests__/pwa-install.test.ts
@@ -1,0 +1,69 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+type InstallModule = typeof import('@/lib/pwa-install');
+
+describe('pwa-install', () => {
+  let mod: InstallModule;
+  let unsubscribe: (() => void) | undefined;
+
+  beforeEach(async () => {
+    vi.resetModules();
+    mod = await import('@/lib/pwa-install');
+  });
+
+  afterEach(() => {
+    unsubscribe?.();
+    vi.restoreAllMocks();
+  });
+
+  it('captures beforeinstallprompt and prevents default', () => {
+    unsubscribe = mod.setupInstallPrompt();
+
+    const event = new Event('beforeinstallprompt');
+    const preventDefault = vi.spyOn(event, 'preventDefault');
+    window.dispatchEvent(event);
+
+    expect(preventDefault).toHaveBeenCalled();
+    expect(mod.canInstall()).toBe(true);
+  });
+
+  it('prompts the user via installPwa and clears the stash', async () => {
+    const prompt = vi.fn<() => Promise<void>>().mockResolvedValue();
+    unsubscribe = mod.setupInstallPrompt();
+
+    const event = new Event('beforeinstallprompt');
+    Object.defineProperty(event, 'prompt', { value: prompt });
+    window.dispatchEvent(event);
+
+    await mod.installPwa();
+
+    expect(prompt).toHaveBeenCalled();
+    expect(mod.canInstall()).toBe(false);
+  });
+
+  it('no-ops installPwa when no prompt is captured', async () => {
+    unsubscribe = mod.setupInstallPrompt();
+
+    await expect(mod.installPwa()).resolves.toBeUndefined();
+  });
+
+  it('clears installability after appinstalled', () => {
+    unsubscribe = mod.setupInstallPrompt();
+
+    window.dispatchEvent(new Event('beforeinstallprompt'));
+    expect(mod.canInstall()).toBe(true);
+
+    window.dispatchEvent(new Event('appinstalled'));
+    expect(mod.canInstall()).toBe(false);
+  });
+
+  it('removes listeners on unsubscribe', () => {
+    unsubscribe = mod.setupInstallPrompt();
+    unsubscribe();
+    unsubscribe = undefined;
+
+    window.dispatchEvent(new Event('beforeinstallprompt'));
+
+    expect(mod.canInstall()).toBe(false);
+  });
+});

--- a/src/lib/__tests__/submission-queue.test.ts
+++ b/src/lib/__tests__/submission-queue.test.ts
@@ -1,0 +1,246 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { PendingSubmission } from '@/lib/indexeddb';
+
+// We must mock the IDB module before importing the queue.
+vi.mock('@/lib/indexeddb', () => ({
+  STORES: { pendingSubmissions: 'pending_submissions' },
+  dbSet: vi.fn(),
+  dbDelete: vi.fn(),
+  dbGetAll: vi.fn(),
+  dbGetAllKeys: vi.fn()
+}));
+
+import { dbDelete, dbGetAll, dbGetAllKeys, dbSet } from '@/lib/indexeddb';
+import {
+  enqueueSubmission,
+  listPendingSubmissions,
+  listenForSyncReplay,
+  pendingCount,
+  registerBackgroundSync,
+  registerSubmissionHandler,
+  removeSubmission,
+  replayPendingSubmissions
+} from '@/lib/submission-queue';
+
+const mockDbSet = vi.mocked(dbSet);
+const mockDbDelete = vi.mocked(dbDelete);
+const mockDbGetAll = vi.mocked(dbGetAll);
+const mockDbGetAllKeys = vi.mocked(dbGetAllKeys);
+
+const storeName = 'pending_submissions';
+
+function makeItem(
+  overrides: Partial<PendingSubmission> = {}
+): PendingSubmission {
+  return {
+    id: 'item-1',
+    ownerId: '',
+    kind: 'assessment',
+    payload: {},
+    createdAt: 1,
+    attempts: 0,
+    ...overrides
+  };
+}
+
+/** Stubs navigator.serviceWorker and returns an emit helper for messages. */
+function stubServiceWorker() {
+  const messageHandlers: Array<(event: MessageEvent) => void> = [];
+  const stub = {
+    addEventListener: vi.fn(
+      (_type: string, handler: (event: MessageEvent) => void) => {
+        messageHandlers.push(handler);
+      }
+    ),
+    removeEventListener: vi.fn(
+      (_type: string, handler: (event: MessageEvent) => void) => {
+        const index = messageHandlers.indexOf(handler);
+        if (index !== -1) messageHandlers.splice(index, 1);
+      }
+    )
+  };
+  Object.defineProperty(navigator, 'serviceWorker', {
+    configurable: true,
+    value: stub
+  });
+  return {
+    emit: (type: string, data?: unknown): void => {
+      for (const handler of messageHandlers) {
+        handler({ data } as MessageEvent);
+      }
+    }
+  };
+}
+
+describe('submission queue', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('enqueueSubmission', () => {
+    it('stores an entry with generated id, kind, payload and zero attempts', async () => {
+      mockDbSet.mockResolvedValue();
+
+      const entry = await enqueueSubmission(
+        'assessment',
+        { item: [{ answer: 1 }] },
+        'guest-1'
+      );
+
+      expect(mockDbSet).toHaveBeenCalledWith(storeName, entry);
+      expect(entry).toMatchObject({
+        ownerId: 'guest-1',
+        kind: 'assessment',
+        payload: { item: [{ answer: 1 }] },
+        attempts: 0
+      });
+      expect(entry.id).toBeTypeOf('string');
+      expect(entry.createdAt).toBeTypeOf('number');
+      expect(entry.id.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('listPendingSubmissions', () => {
+    it('returns all stored pending submissions', async () => {
+      const items = [makeItem({ id: 'a' }), makeItem({ id: 'b' })];
+      mockDbGetAll.mockResolvedValue(items);
+
+      await expect(listPendingSubmissions()).resolves.toEqual(items);
+      expect(mockDbGetAll).toHaveBeenCalledWith(storeName);
+    });
+  });
+
+  describe('pendingCount', () => {
+    it('counts stored keys', async () => {
+      mockDbGetAllKeys.mockResolvedValue(['a', 'b', 'c']);
+
+      await expect(pendingCount()).resolves.toBe(3);
+      expect(mockDbGetAllKeys).toHaveBeenCalledWith(storeName);
+    });
+  });
+
+  describe('removeSubmission', () => {
+    it('deletes the entry by id', async () => {
+      mockDbDelete.mockResolvedValue();
+
+      await removeSubmission('item-1');
+
+      expect(mockDbDelete).toHaveBeenCalledWith(storeName, 'item-1');
+    });
+  });
+
+  describe('replayPendingSubmissions', () => {
+    it('deletes a submission after its handler succeeds', async () => {
+      const handler = vi.fn<() => Promise<void>>().mockResolvedValue();
+      registerSubmissionHandler('assessment', handler);
+      mockDbGetAll.mockResolvedValue([
+        makeItem({ id: 'a', payload: { q: 1 } })
+      ]);
+      mockDbDelete.mockResolvedValue();
+
+      await replayPendingSubmissions();
+
+      expect(handler).toHaveBeenCalledWith({ q: 1 });
+      expect(mockDbDelete).toHaveBeenCalledWith(storeName, 'a');
+      // No re-put with incremented attempts on success.
+      expect(mockDbSet).not.toHaveBeenCalled();
+    });
+
+    it('keeps the submission and increments attempts when the handler fails', async () => {
+      registerSubmissionHandler(
+        'assessment',
+        vi
+          .fn<() => Promise<void>>()
+          .mockRejectedValue(new Error('network down'))
+      );
+      mockDbGetAll.mockResolvedValue([makeItem({ id: 'a', attempts: 2 })]);
+      mockDbSet.mockResolvedValue();
+
+      await replayPendingSubmissions();
+
+      expect(mockDbDelete).not.toHaveBeenCalled();
+      expect(mockDbSet).toHaveBeenCalledWith(
+        storeName,
+        expect.objectContaining({ id: 'a', attempts: 3 })
+      );
+    });
+
+    it('skips submissions whose kind has no registered handler', async () => {
+      mockDbGetAll.mockResolvedValue([
+        makeItem({ id: 'a', kind: 'unknown-kind' })
+      ]);
+
+      await expect(replayPendingSubmissions()).resolves.toBeUndefined();
+
+      expect(mockDbDelete).not.toHaveBeenCalled();
+      expect(mockDbSet).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('listenForSyncReplay', () => {
+    it('replays the queue when a SYNC_REPLAY message arrives', async () => {
+      mockDbGetAll.mockResolvedValue([]);
+      const { emit } = stubServiceWorker();
+
+      listenForSyncReplay();
+      emit('message', { type: 'SYNC_REPLAY' });
+
+      await vi.waitFor(() => {
+        expect(mockDbGetAll).toHaveBeenCalledWith(storeName);
+      });
+    });
+
+    it('ignores unrelated messages', async () => {
+      mockDbGetAll.mockResolvedValue([]);
+      const { emit } = stubServiceWorker();
+
+      listenForSyncReplay();
+      emit('message', { type: 'SOMETHING_ELSE' });
+
+      await new Promise(resolve => setTimeout(resolve, 10));
+      expect(mockDbGetAll).not.toHaveBeenCalled();
+    });
+
+    it('returns a no-op unsubscribe when serviceWorker is missing', () => {
+      Reflect.deleteProperty(navigator, 'serviceWorker');
+      const unsubscribe = listenForSyncReplay();
+      expect(typeof unsubscribe).toBe('function');
+    });
+  });
+
+  describe('registerBackgroundSync', () => {
+    it('registers the replay tag when SyncManager is supported', async () => {
+      const syncRegister = vi.fn<() => Promise<void>>().mockResolvedValue();
+      Object.defineProperty(navigator, 'serviceWorker', {
+        configurable: true,
+        value: {
+          ready: Promise.resolve({ sync: { register: syncRegister } })
+        }
+      });
+
+      await registerBackgroundSync();
+
+      expect(syncRegister).toHaveBeenCalledWith('replay-pending');
+    });
+
+    it('no-ops when SyncManager is unavailable', async () => {
+      Object.defineProperty(navigator, 'serviceWorker', {
+        configurable: true,
+        value: { ready: Promise.resolve({}) }
+      });
+
+      await expect(registerBackgroundSync()).resolves.toBeUndefined();
+    });
+
+    it('no-ops when navigator.serviceWorker is missing', async () => {
+      Reflect.deleteProperty(navigator, 'serviceWorker');
+
+      await expect(registerBackgroundSync()).resolves.toBeUndefined();
+    });
+  });
+});

--- a/src/lib/__tests__/submission-queue.test.ts
+++ b/src/lib/__tests__/submission-queue.test.ts
@@ -103,6 +103,40 @@ describe('submission queue', () => {
       expect(entry.createdAt).toBeTypeOf('number');
       expect(entry.id.length).toBeGreaterThan(0);
     });
+
+    it('falls back to a CSPRNG segment id when crypto.randomUUID is missing', async () => {
+      mockDbSet.mockResolvedValue();
+      const first = 42;
+      const second = 77;
+      const getRandomValues = vi.fn(() => new Uint32Array([first, second]));
+      vi.stubGlobal('crypto', { getRandomValues });
+      try {
+        const entry = await enqueueSubmission('assessment', {});
+        expect(getRandomValues).toHaveBeenCalled();
+        expect(entry.id).toBe(
+          `pending-${entry.createdAt}-${first.toString(36)}${second.toString(36)}`
+        );
+      } finally {
+        vi.unstubAllGlobals();
+      }
+    });
+
+    it('falls back to a timestamp-only id when crypto is absent', async () => {
+      mockDbSet.mockResolvedValue();
+      const cryptoDescriptor = Object.getOwnPropertyDescriptor(
+        globalThis,
+        'crypto'
+      );
+      Reflect.deleteProperty(globalThis, 'crypto');
+      try {
+        const entry = await enqueueSubmission('assessment', {});
+        expect(entry.id).toBe(`pending-${entry.createdAt}`);
+      } finally {
+        if (cryptoDescriptor) {
+          Object.defineProperty(globalThis, 'crypto', cryptoDescriptor);
+        }
+      }
+    });
   });
 
   describe('listPendingSubmissions', () => {

--- a/src/lib/__tests__/submission-replay.test.ts
+++ b/src/lib/__tests__/submission-replay.test.ts
@@ -1,0 +1,120 @@
+import type { QueryClient } from '@tanstack/react-query';
+import type { AxiosInstance } from 'axios';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Registry shared between the mock factory and the tests (mock-prefixed so
+// vitest can hoist the factory safely).
+const mockRegistry = new Map<string, (payload: unknown) => Promise<void>>();
+
+vi.mock('@/lib/submission-queue', () => ({
+  registerSubmissionHandler: (
+    kind: string,
+    fn: (payload: unknown) => Promise<void>
+  ) => {
+    mockRegistry.set(kind, fn);
+  }
+}));
+
+vi.mock('@/services/api', () => ({ getAPI: vi.fn() }));
+
+vi.mock('@/components/general/query-provider', () => ({
+  getAppQueryClient: vi.fn()
+}));
+
+import { getAppQueryClient } from '@/components/general/query-provider';
+import {
+  isNetworkError,
+  QUESTIONNAIRE_RESPONSE_KIND,
+  registerSubmissionReplayHandlers,
+  SOAP_BUNDLE_KIND
+} from '@/lib/submission-replay';
+import { getAPI } from '@/services/api';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('registerSubmissionReplayHandlers', () => {
+  it('registers handlers for both submission kinds', () => {
+    registerSubmissionReplayHandlers();
+
+    expect(mockRegistry.has(QUESTIONNAIRE_RESPONSE_KIND)).toBe(true);
+    expect(mockRegistry.has(SOAP_BUNDLE_KIND)).toBe(true);
+  });
+});
+
+describe('questionnaire response replay', () => {
+  it('re-posts the stored payload to /fhir/QuestionnaireResponse', async () => {
+    const mockPost = vi.fn().mockResolvedValue({ data: {} });
+    vi.mocked(getAPI).mockResolvedValue({
+      post: mockPost
+    } as unknown as AxiosInstance);
+
+    registerSubmissionReplayHandlers();
+    const handler = mockRegistry.get(QUESTIONNAIRE_RESPONSE_KIND);
+    expect(handler).toBeDefined();
+
+    const payload = { resourceType: 'QuestionnaireResponse', id: 'QR-1' };
+    await handler?.(payload);
+
+    expect(mockPost).toHaveBeenCalledWith(
+      '/fhir/QuestionnaireResponse',
+      payload
+    );
+  });
+
+  it('invalidates research queries after a successful replay', async () => {
+    const mockPost = vi.fn().mockResolvedValue({ data: {} });
+    vi.mocked(getAPI).mockResolvedValue({
+      post: mockPost
+    } as unknown as AxiosInstance);
+    const invalidateQueries = vi.fn();
+    vi.mocked(getAppQueryClient).mockReturnValue({
+      invalidateQueries
+    } as unknown as QueryClient);
+
+    registerSubmissionReplayHandlers();
+    const handler = mockRegistry.get(QUESTIONNAIRE_RESPONSE_KIND);
+
+    await handler?.({ resourceType: 'QuestionnaireResponse' });
+
+    expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: ['research'] });
+  });
+});
+
+describe('soap bundle replay', () => {
+  it('re-posts the stored bundle to /fhir', async () => {
+    const mockPost = vi.fn().mockResolvedValue({ data: {} });
+    vi.mocked(getAPI).mockResolvedValue({
+      post: mockPost
+    } as unknown as AxiosInstance);
+
+    registerSubmissionReplayHandlers();
+    const handler = mockRegistry.get(SOAP_BUNDLE_KIND);
+    expect(handler).toBeDefined();
+
+    const bundle = { resourceType: 'Bundle', type: 'transaction', entry: [] };
+    await handler?.(bundle);
+
+    expect(mockPost).toHaveBeenCalledWith('/fhir', bundle);
+  });
+});
+
+describe('isNetworkError', () => {
+  it('treats ERR_NETWORK codes as network failures', () => {
+    expect(isNetworkError({ code: 'ERR_NETWORK' })).toBe(true);
+  });
+
+  it('treats errors without a response as network failures', () => {
+    expect(isNetworkError({ message: 'Network Error' })).toBe(true);
+  });
+
+  it('treats HTTP errors with a response as non-network failures', () => {
+    expect(isNetworkError({ response: { status: 500 } })).toBe(false);
+  });
+
+  it('treats non-objects as non-network failures', () => {
+    expect(isNetworkError('string')).toBe(false);
+    expect(isNetworkError(null)).toBe(false);
+  });
+});

--- a/src/lib/__tests__/sw-lifecycle.test.ts
+++ b/src/lib/__tests__/sw-lifecycle.test.ts
@@ -163,6 +163,28 @@ describe('sync event', () => {
 });
 
 // ---------------------------------------------------------------------------
+// Message event
+// ---------------------------------------------------------------------------
+describe('message event', () => {
+  it('calls skipWaiting() on a SKIP_WAITING message', () => {
+    const handler = mockSelf.handlers.message[0];
+    expect(handler, 'message handler must be registered').toBeDefined();
+
+    handler({ data: { type: 'SKIP_WAITING' } });
+
+    expect(mockSelf.skipWaiting).toHaveBeenCalled();
+  });
+
+  it('ignores messages without the SKIP_WAITING type', () => {
+    const handler = mockSelf.handlers.message[0];
+
+    handler({ data: { type: 'SOMETHING_ELSE' } });
+
+    expect(mockSelf.skipWaiting).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Fetch event - routing
 // ---------------------------------------------------------------------------
 describe('fetch event routing', () => {

--- a/src/lib/__tests__/sw-lifecycle.test.ts
+++ b/src/lib/__tests__/sw-lifecycle.test.ts
@@ -1,5 +1,6 @@
 /* eslint-disable unicorn/prefer-https */
 /* eslint-disable @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call, sonarjs/code-eval, @typescript-eslint/no-implied-eval, unicorn/text-encoding-identifier-case */
+/* eslint-disable max-lines */
 import { existsSync, readFileSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -22,6 +23,7 @@ import {
   fireActivate,
   fireFetch,
   fireInstall,
+  fireSync,
   type MockCaches,
   type MockSelf
 } from '@/__tests__/test-utils';
@@ -133,6 +135,30 @@ describe('activate event', () => {
     await awaitEvent(event);
 
     expect(mockSelf.clients.claim).toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Sync event
+// ---------------------------------------------------------------------------
+describe('sync event', () => {
+  it('broadcasts SYNC_REPLAY to all clients for the replay-pending tag', async () => {
+    const clientA = { postMessage: vi.fn() };
+    const clientB = { postMessage: vi.fn() };
+    mockSelf.clients.matchAll.mockResolvedValue([clientA, clientB]);
+
+    const event = fireSync(mockSelf, 'replay-pending');
+    await awaitEvent(event);
+
+    expect(mockSelf.clients.matchAll).toHaveBeenCalled();
+    expect(clientA.postMessage).toHaveBeenCalledWith({ type: 'SYNC_REPLAY' });
+    expect(clientB.postMessage).toHaveBeenCalledWith({ type: 'SYNC_REPLAY' });
+  });
+
+  it('ignores sync events for other tags', () => {
+    const event = fireSync(mockSelf, 'other-tag');
+
+    expect(event.waitUntil).not.toHaveBeenCalled();
   });
 });
 
@@ -363,8 +389,8 @@ describe('sw-register.js', () => {
 describe('defense-in-depth URL validation', () => {
   it('networkFirst returns 503 for non-http URLs', async () => {
     const patchedCode = SW_CODE.replace(
-      'async function networkFirst (request, cacheName, fallbackUrl) {',
-      'self.__testNetworkFirst = async function networkFirst (request, cacheName, fallbackUrl) {'
+      'async function networkFirst(request, cacheName, fallbackUrl) {',
+      'self.__testNetworkFirst = async function networkFirst(request, cacheName, fallbackUrl) {'
     );
 
     const captureSelf = createMockSelf() as MockSelf & {

--- a/src/lib/__tests__/sw-lifecycle.test.ts
+++ b/src/lib/__tests__/sw-lifecycle.test.ts
@@ -79,8 +79,8 @@ describe('install event', () => {
     const event = fireInstall(mockSelf);
     await awaitEvent(event);
 
-    expect(mockCaches.open).toHaveBeenCalledWith('konsulin-static-v1');
-    expect(mockCaches.stores['konsulin-static-v1'].addAll).toHaveBeenCalledWith(
+    expect(mockCaches.open).toHaveBeenCalledWith('konsulin-static-v2');
+    expect(mockCaches.stores['konsulin-static-v2'].addAll).toHaveBeenCalledWith(
       ['/~offline', '/manifest.json', '/images/Loading-Time.svg']
     );
   });
@@ -108,14 +108,14 @@ describe('activate event', () => {
 
   it('preserves current version caches', async () => {
     mockCaches.stores['konsulin-old-v1'] = createMockCache();
-    mockCaches.stores['konsulin-static-v1'] = createMockCache();
-    mockCaches.stores['konsulin-nav-v1'] = createMockCache();
+    mockCaches.stores['konsulin-static-v2'] = createMockCache();
+    mockCaches.stores['konsulin-nav-v2'] = createMockCache();
 
     const event = fireActivate(mockSelf);
     await awaitEvent(event);
 
-    expect(mockCaches.delete).not.toHaveBeenCalledWith('konsulin-static-v1');
-    expect(mockCaches.delete).not.toHaveBeenCalledWith('konsulin-nav-v1');
+    expect(mockCaches.delete).not.toHaveBeenCalledWith('konsulin-static-v2');
+    expect(mockCaches.delete).not.toHaveBeenCalledWith('konsulin-nav-v2');
     expect(mockCaches.delete).toHaveBeenCalledTimes(1); // only old cache
   });
 
@@ -215,14 +215,14 @@ describe('fetch event routing', () => {
 
     expect(event.respondWith).toHaveBeenCalled();
     // networkFirst opens cache after network fetch succeeds
-    expect(mockCaches.open).toHaveBeenCalledWith('konsulin-static-v1');
+    expect(mockCaches.open).toHaveBeenCalledWith('konsulin-static-v2');
   });
 
   it('fetches static assets from network even when cached (networkFirst behavior)', () => {
     // Pre-populate cache so cacheFirst would return cached without fetching
     const cachedResponse = new Response('cached', { status: 200 });
-    mockCaches.stores['konsulin-static-v1'] = createMockCache();
-    mockCaches.stores['konsulin-static-v1'].match.mockResolvedValue(
+    mockCaches.stores['konsulin-static-v2'] = createMockCache();
+    mockCaches.stores['konsulin-static-v2'].match.mockResolvedValue(
       cachedResponse
     );
 
@@ -241,7 +241,8 @@ describe('fetch event routing', () => {
 
   it('routes proxy API directly to fetch (no cache)', () => {
     const event = fireFetch(mockSelf, {
-      url: 'http://konsulin.care/proxy/fhir/Patient'
+      url: 'http://konsulin.care/proxy/fhir/Patient',
+      method: 'GET'
     });
 
     expect(event.respondWith).toHaveBeenCalled();
@@ -250,6 +251,68 @@ describe('fetch event routing', () => {
         url: 'http://konsulin.care/proxy/fhir/Patient'
       })
     );
+    expect(mockCaches.open).not.toHaveBeenCalled();
+  });
+
+  it('routes /proxy/fhir/Questionnaire GETs through networkFirst (caches on success)', async () => {
+    const event = fireFetch(mockSelf, {
+      url: 'http://konsulin.care/proxy/fhir/Questionnaire?_id=abc',
+      method: 'GET'
+    });
+    await awaitEvent(event);
+
+    expect(event.respondWith).toHaveBeenCalled();
+    expect(mockFetch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url: 'http://konsulin.care/proxy/fhir/Questionnaire?_id=abc'
+      })
+    );
+    expect(mockCaches.open).toHaveBeenCalledWith('konsulin-nav-v2');
+  });
+
+  it('serves a cached Questionnaire when the network fails', async () => {
+    mockFetch.mockRejectedValue(new Error('Offline'));
+    const cachedResponse = new Response('cached questionnaire', {
+      status: 200
+    });
+    mockCaches.stores['konsulin-nav-v2'] = createMockCache();
+    mockCaches.stores['konsulin-nav-v2'].match.mockResolvedValue(
+      cachedResponse
+    );
+
+    const event = fireFetch(mockSelf, {
+      url: 'http://konsulin.care/proxy/fhir/Questionnaire/soap',
+      method: 'GET'
+    });
+
+    const response = await awaitEvent(event);
+    expect(response).toBe(cachedResponse);
+  });
+
+  it('routes /proxy/fhir/QuestionnaireResponse through raw fetch (no cache)', () => {
+    const event = fireFetch(mockSelf, {
+      url: 'http://konsulin.care/proxy/fhir/QuestionnaireResponse',
+      method: 'GET'
+    });
+
+    expect(event.respondWith).toHaveBeenCalled();
+    expect(mockFetch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url: 'http://konsulin.care/proxy/fhir/QuestionnaireResponse'
+      })
+    );
+    expect(mockCaches.open).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    'http://konsulin.care/auth/cookie',
+    'http://konsulin.care/auth/cookie/csrf-token',
+    'http://konsulin.care/api/config'
+  ])('routes %s through raw fetch (never cached)', url => {
+    const event = fireFetch(mockSelf, { url, method: 'GET' });
+
+    expect(event.respondWith).toHaveBeenCalled();
+    expect(mockFetch).toHaveBeenCalledWith(expect.objectContaining({ url }));
     expect(mockCaches.open).not.toHaveBeenCalled();
   });
 
@@ -295,8 +358,8 @@ describe('fetch offline fallback', () => {
 
     // Pre-populate static cache with the offline fallback page
     const offlineResponse = new Response('offline page', { status: 200 });
-    mockCaches.stores['konsulin-static-v1'] = createMockCache();
-    mockCaches.stores['konsulin-static-v1'].match.mockImplementation(
+    mockCaches.stores['konsulin-static-v2'] = createMockCache();
+    mockCaches.stores['konsulin-static-v2'].match.mockImplementation(
       (url: string) => {
         if (url === '/~offline') return Promise.resolve(offlineResponse);
         return Promise.resolve();
@@ -311,16 +374,16 @@ describe('fetch offline fallback', () => {
 
     const response = await awaitEvent(event);
     expect(response).toBe(offlineResponse);
-    expect(mockCaches.open).toHaveBeenCalledWith('konsulin-nav-v1');
-    expect(mockCaches.open).toHaveBeenCalledWith('konsulin-static-v1');
+    expect(mockCaches.open).toHaveBeenCalledWith('konsulin-nav-v2');
+    expect(mockCaches.open).toHaveBeenCalledWith('konsulin-static-v2');
   });
 
   it('serves cached page when network fails on navigation', async () => {
     mockFetch.mockRejectedValue(new Error('Offline'));
 
     const cachedResponse = new Response('cached page', { status: 200 });
-    mockCaches.stores['konsulin-nav-v1'] = createMockCache();
-    mockCaches.stores['konsulin-nav-v1'].match.mockResolvedValue(
+    mockCaches.stores['konsulin-nav-v2'] = createMockCache();
+    mockCaches.stores['konsulin-nav-v2'].match.mockResolvedValue(
       cachedResponse
     );
 
@@ -333,7 +396,7 @@ describe('fetch offline fallback', () => {
     const response = await awaitEvent(event);
     expect(response).toBe(cachedResponse);
     // Should NOT reach the static cache fallback
-    expect(mockCaches.open).not.toHaveBeenCalledWith('konsulin-static-v1');
+    expect(mockCaches.open).not.toHaveBeenCalledWith('konsulin-static-v2');
   });
 });
 

--- a/src/lib/__tests__/sw-lifecycle.test.ts
+++ b/src/lib/__tests__/sw-lifecycle.test.ts
@@ -474,8 +474,8 @@ describe('sw-register.js', () => {
 describe('defense-in-depth URL validation', () => {
   it('networkFirst returns 503 for non-http URLs', async () => {
     const patchedCode = SW_CODE.replace(
-      'async function networkFirst(request, cacheName, fallbackUrl) {',
-      'self.__testNetworkFirst = async function networkFirst(request, cacheName, fallbackUrl) {'
+      'async function networkFirst (request, cacheName, fallbackUrl) {',
+      'self.__testNetworkFirst = async function networkFirst (request, cacheName, fallbackUrl) {'
     );
 
     const captureSelf = createMockSelf() as MockSelf & {

--- a/src/lib/__tests__/sw-lifecycle.test.ts
+++ b/src/lib/__tests__/sw-lifecycle.test.ts
@@ -166,11 +166,13 @@ describe('sync event', () => {
 // Message event
 // ---------------------------------------------------------------------------
 describe('message event', () => {
-  it('calls skipWaiting() on a SKIP_WAITING message', () => {
+  const SAME_ORIGIN = 'http://konsulin.care';
+
+  it('calls skipWaiting() on a same-origin SKIP_WAITING message', () => {
     const handler = mockSelf.handlers.message[0];
     expect(handler, 'message handler must be registered').toBeDefined();
 
-    handler({ data: { type: 'SKIP_WAITING' } });
+    handler({ origin: SAME_ORIGIN, data: { type: 'SKIP_WAITING' } });
 
     expect(mockSelf.skipWaiting).toHaveBeenCalled();
   });
@@ -178,7 +180,18 @@ describe('message event', () => {
   it('ignores messages without the SKIP_WAITING type', () => {
     const handler = mockSelf.handlers.message[0];
 
-    handler({ data: { type: 'SOMETHING_ELSE' } });
+    handler({ origin: SAME_ORIGIN, data: { type: 'SOMETHING_ELSE' } });
+
+    expect(mockSelf.skipWaiting).not.toHaveBeenCalled();
+  });
+
+  it('rejects SKIP_WAITING messages from other origins', () => {
+    const handler = mockSelf.handlers.message[0];
+
+    handler({
+      origin: 'https://evil.example',
+      data: { type: 'SKIP_WAITING' }
+    });
 
     expect(mockSelf.skipWaiting).not.toHaveBeenCalled();
   });
@@ -474,8 +487,8 @@ describe('sw-register.js', () => {
 describe('defense-in-depth URL validation', () => {
   it('networkFirst returns 503 for non-http URLs', async () => {
     const patchedCode = SW_CODE.replace(
-      'async function networkFirst (request, cacheName, fallbackUrl) {',
-      'self.__testNetworkFirst = async function networkFirst (request, cacheName, fallbackUrl) {'
+      'async function networkFirst(request, cacheName, fallbackUrl) {',
+      'self.__testNetworkFirst = async function networkFirst(request, cacheName, fallbackUrl) {'
     );
 
     const captureSelf = createMockSelf() as MockSelf & {

--- a/src/lib/__tests__/sw-update.test.tsx
+++ b/src/lib/__tests__/sw-update.test.tsx
@@ -1,0 +1,173 @@
+import {
+  applySwUpdate,
+  setupSwUpdateDetection,
+  SKIP_WAITING_MESSAGE
+} from '@/lib/sw-update';
+import { toast } from 'react-toastify';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('react-toastify', () => ({
+  toast: { info: vi.fn(), dismiss: vi.fn() }
+}));
+
+function stubServiceWorker(sw: Record<string, unknown>) {
+  Object.defineProperty(navigator, 'serviceWorker', {
+    configurable: true,
+    value: sw
+  });
+}
+
+type MockListenerFn = (type: string, handler: () => void) => void;
+
+describe('setupSwUpdateDetection', () => {
+  let originalLocation: Location;
+
+  beforeEach(() => {
+    originalLocation = window.location;
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: originalLocation
+    });
+  });
+
+  it('shows an update toast when a new worker finishes installing', async () => {
+    const worker = {
+      addEventListener: vi.fn<MockListenerFn>(),
+      state: 'installing'
+    };
+    const registration = {
+      installing: worker,
+      waiting: null,
+      addEventListener: vi.fn<MockListenerFn>()
+    };
+    stubServiceWorker({
+      ready: Promise.resolve(registration),
+      controller: {},
+      addEventListener: vi.fn()
+    });
+
+    const unsubscribe = setupSwUpdateDetection();
+
+    await vi.waitFor(() => {
+      expect(registration.addEventListener).toHaveBeenCalledWith(
+        'updatefound',
+        expect.any(Function)
+      );
+    });
+    const updateFoundHandler = registration.addEventListener.mock.calls[0][1];
+    updateFoundHandler();
+
+    expect(worker.addEventListener).toHaveBeenCalledWith(
+      'statechange',
+      expect.any(Function)
+    );
+    const stateHandler = worker.addEventListener.mock.calls[0][1];
+    worker.state = 'installed';
+    stateHandler();
+
+    expect(toast.info).toHaveBeenCalled();
+    unsubscribe();
+  });
+
+  it('does not notify on the first install (no active controller)', async () => {
+    const worker = {
+      addEventListener: vi.fn<MockListenerFn>(),
+      state: 'installing'
+    };
+    const registration = {
+      installing: worker,
+      waiting: null,
+      addEventListener: vi.fn<MockListenerFn>()
+    };
+    stubServiceWorker({
+      ready: Promise.resolve(registration),
+      controller: null,
+      addEventListener: vi.fn()
+    });
+
+    const unsubscribe = setupSwUpdateDetection();
+
+    await vi.waitFor(() => {
+      expect(registration.addEventListener).toHaveBeenCalledWith(
+        'updatefound',
+        expect.any(Function)
+      );
+    });
+    const updateFoundHandler = registration.addEventListener.mock.calls[0][1];
+    updateFoundHandler();
+
+    const stateHandler = worker.addEventListener.mock.calls[0][1];
+    worker.state = 'installed';
+    stateHandler();
+
+    expect(toast.info).not.toHaveBeenCalled();
+    unsubscribe();
+  });
+
+  it('returns a no-op unsubscribe when service workers are unsupported', () => {
+    Reflect.deleteProperty(navigator, 'serviceWorker');
+
+    const unsubscribe = setupSwUpdateDetection();
+
+    expect(typeof unsubscribe).toBe('function');
+  });
+});
+
+describe('applySwUpdate', () => {
+  let originalLocation: Location;
+
+  beforeEach(() => {
+    originalLocation = window.location;
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: originalLocation
+    });
+  });
+
+  it('posts SKIP_WAITING and reloads when the new worker takes control', () => {
+    const postMessage = vi.fn();
+    const controllerHandlers: Array<() => void> = [];
+    stubServiceWorker({
+      addEventListener: vi.fn((_type: string, fn: () => void) => {
+        controllerHandlers.push(fn);
+      })
+    });
+    const reload = vi.fn();
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: { reload }
+    });
+
+    applySwUpdate({
+      waiting: { postMessage }
+    } as unknown as ServiceWorkerRegistration);
+
+    expect(postMessage).toHaveBeenCalledWith({ type: SKIP_WAITING_MESSAGE });
+    expect(reload).not.toHaveBeenCalled();
+    controllerHandlers.forEach(fn => fn());
+    expect(reload).toHaveBeenCalled();
+  });
+
+  it('reloads immediately when no worker is waiting', () => {
+    const reload = vi.fn();
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: { reload }
+    });
+    stubServiceWorker({ addEventListener: vi.fn() });
+
+    applySwUpdate({ waiting: null } as unknown as ServiceWorkerRegistration);
+
+    expect(reload).toHaveBeenCalled();
+  });
+});

--- a/src/lib/api-retry.ts
+++ b/src/lib/api-retry.ts
@@ -44,6 +44,15 @@ export function shouldRetryRequest(
 }
 
 /**
+ * Returns a random float in [0, 1) using the platform CSPRNG.
+ * Provides the jitter for retry backoff without a weak RNG.
+ */
+function randomUnit(): number {
+  const buffer = new Uint32Array(1);
+  return crypto.getRandomValues(buffer)[0] / 2 ** 32;
+}
+
+/**
  * Computes the backoff delay for a retry attempt: exponential base delay
  * plus bounded random jitter to avoid thundering-herd retries.
  *
@@ -52,6 +61,5 @@ export function shouldRetryRequest(
  */
 export function getRetryDelayMs(attempt: number): number {
   const base = BASE_RETRY_DELAY_MS * 2 ** attempt;
-  // NOSONAR - Math.random is fine for retry jitter, not a security boundary
-  return base + Math.random() * MAX_JITTER_MS;
+  return base + randomUnit() * MAX_JITTER_MS;
 }

--- a/src/lib/api-retry.ts
+++ b/src/lib/api-retry.ts
@@ -1,0 +1,56 @@
+/** Maximum retries per request (1 initial attempt + MAX_RETRY_COUNT retries). */
+export const MAX_RETRY_COUNT = 2;
+
+/** Base delay for the first retry, doubled on each subsequent attempt. */
+export const BASE_RETRY_DELAY_MS = 500;
+
+/** Maximum random jitter added to each backoff delay. */
+export const MAX_JITTER_MS = 200;
+
+/**
+ * True when an axios-style error means no HTTP response was received
+ * (network-level failure rather than a server response).
+ */
+export function isNetworkError(error: unknown): boolean {
+  if (typeof error !== 'object' || error === null) return false;
+  const err = error as { response?: unknown; code?: string };
+  return err.response === undefined || err.code === 'ERR_NETWORK';
+}
+
+/**
+ * Decides whether a failed request should be retried.
+ *
+ * Only idempotent GET requests are retried, only for network-level failures
+ * or server errors (>= 500), and only while the retry budget is available.
+ * 4xx responses (including 401/403) are never retried.
+ *
+ * @param error - The axios error from the failed request.
+ * @param config - The request config, used to check the HTTP method.
+ * @param retryCount - Number of retries already attempted.
+ * @returns True when the request should be retried.
+ */
+export function shouldRetryRequest(
+  error: unknown,
+  config: { method?: string } | undefined,
+  retryCount: number
+): boolean {
+  if ((config?.method ?? '').toUpperCase() !== 'GET') return false;
+  if (retryCount >= MAX_RETRY_COUNT) return false;
+  if (isNetworkError(error)) return true;
+
+  const status = (error as { response?: { status?: unknown } }).response
+    ?.status;
+  return typeof status === 'number' && status >= 500;
+}
+
+/**
+ * Computes the backoff delay for a retry attempt: exponential base delay
+ * plus bounded random jitter to avoid thundering-herd retries.
+ *
+ * @param attempt - Zero-based retry attempt index.
+ * @returns Delay in milliseconds, in [base, base + MAX_JITTER_MS].
+ */
+export function getRetryDelayMs(attempt: number): number {
+  const base = BASE_RETRY_DELAY_MS * 2 ** attempt;
+  return base + Math.random() * MAX_JITTER_MS;
+}

--- a/src/lib/api-retry.ts
+++ b/src/lib/api-retry.ts
@@ -52,5 +52,6 @@ export function shouldRetryRequest(
  */
 export function getRetryDelayMs(attempt: number): number {
   const base = BASE_RETRY_DELAY_MS * 2 ** attempt;
+  // NOSONAR - Math.random is fine for retry jitter, not a security boundary
   return base + Math.random() * MAX_JITTER_MS;
 }

--- a/src/lib/connectivity.ts
+++ b/src/lib/connectivity.ts
@@ -1,0 +1,91 @@
+export type ConnectivityStatus = 'stable' | 'unstable' | 'offline';
+
+/** Failures older than this window no longer count toward "unstable". */
+export const FAILURE_WINDOW_MS = 30_000;
+
+/** Failures within the window required to flip to "unstable". */
+export const UNSTABLE_FAILURE_THRESHOLD = 2;
+
+type Listener = (status: ConnectivityStatus) => void;
+
+const listeners = new Set<Listener>();
+let failureTimes: number[] = [];
+let forceOffline = false;
+let initialized = false;
+
+/** True when the browser reports the network as fully offline. */
+function browserIsOffline(): boolean {
+  return (
+    typeof navigator !== 'undefined' &&
+    typeof navigator.onLine === 'boolean' &&
+    !navigator.onLine
+  );
+}
+
+/** Computes the current status from browser state and recorded failures. */
+function computeStatus(): ConnectivityStatus {
+  if (forceOffline || browserIsOffline()) return 'offline';
+  const cutoff = Date.now() - FAILURE_WINDOW_MS;
+  const recentFailures = failureTimes.filter(time => time >= cutoff);
+  if (recentFailures.length >= UNSTABLE_FAILURE_THRESHOLD) return 'unstable';
+  return 'stable';
+}
+
+/** Notifies all subscribers of the latest status. */
+function emit(): void {
+  const status = computeStatus();
+  for (const listener of listeners) {
+    listener(status);
+  }
+}
+
+/**
+ * Records the outcome of a real request. A success clears the failure
+ * window (no intervening success), while a failure is timestamped and
+ * counted toward the "unstable" threshold.
+ *
+ * @param ok - True when the request succeeded.
+ */
+export function reportRequestOutcome(ok: boolean): void {
+  if (ok) {
+    failureTimes = [];
+  } else {
+    failureTimes.push(Date.now());
+  }
+  emit();
+}
+
+/** Returns the current connectivity status. */
+export function getStatus(): ConnectivityStatus {
+  return computeStatus();
+}
+
+/**
+ * Subscribes to status changes.
+ *
+ * @param listener - Called with the new status on every change.
+ * @returns An unsubscribe function.
+ */
+export function subscribe(listener: Listener): () => void {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+/**
+ * Attaches window online/offline listeners as a hard signal. Idempotent.
+ * No-op outside the browser (SSR, tests without a window).
+ */
+export function initConnectivity(): void {
+  if (initialized || typeof window === 'undefined') return;
+  initialized = true;
+  window.addEventListener('offline', () => {
+    forceOffline = true;
+    emit();
+  });
+  window.addEventListener('online', () => {
+    forceOffline = false;
+    emit();
+  });
+}

--- a/src/lib/indexeddb.ts
+++ b/src/lib/indexeddb.ts
@@ -1,6 +1,6 @@
 /* eslint-disable max-lines, @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unnecessary-type-parameters, unicorn/prefer-includes-over-repeated-comparisons, unicorn/prefer-add-event-listener */
 const DB_NAME = 'konsulin';
-const DB_VERSION = 2;
+export const DB_VERSION = 3;
 
 export const STORES = {
   guestSessions: 'guest_sessions',
@@ -10,21 +10,34 @@ export const STORES = {
   tempBooking: 'temp_booking',
   uiPreferences: 'ui_preferences',
   navigationState: 'navigation_state',
-  userProfile: 'user_profile'
+  userProfile: 'user_profile',
+  pendingSubmissions: 'pending_submissions'
 } as const;
 
 export type StoreName = (typeof STORES)[keyof typeof STORES];
 
-const STORE_SCHEMAS: { name: StoreName; keyPath: string | string[] }[] = [
-  { name: STORES.guestSessions, keyPath: 'guest_id' },
-  { name: STORES.assessmentDrafts, keyPath: ['ownerId', 'questionnaireId'] },
-  { name: STORES.soapDrafts, keyPath: ['practitionerId', 'patientId'] },
-  { name: STORES.serviceRequests, keyPath: 'id' },
-  { name: STORES.tempBooking, keyPath: 'ownerId' },
-  { name: STORES.uiPreferences, keyPath: ['ownerId', 'prefKey'] },
-  { name: STORES.navigationState, keyPath: ['ownerId', 'stateKey'] },
-  { name: STORES.userProfile, keyPath: 'userId' }
-];
+/** A submission that failed to send and is waiting for a replay attempt. */
+export type PendingSubmission<T = unknown> = {
+  id: string;
+  ownerId: string;
+  kind: string;
+  payload: T;
+  createdAt: number;
+  attempts: number;
+};
+
+export const STORE_SCHEMAS: { name: StoreName; keyPath: string | string[] }[] =
+  [
+    { name: STORES.guestSessions, keyPath: 'guest_id' },
+    { name: STORES.assessmentDrafts, keyPath: ['ownerId', 'questionnaireId'] },
+    { name: STORES.soapDrafts, keyPath: ['practitionerId', 'patientId'] },
+    { name: STORES.serviceRequests, keyPath: 'id' },
+    { name: STORES.tempBooking, keyPath: 'ownerId' },
+    { name: STORES.uiPreferences, keyPath: ['ownerId', 'prefKey'] },
+    { name: STORES.navigationState, keyPath: ['ownerId', 'stateKey'] },
+    { name: STORES.userProfile, keyPath: 'userId' },
+    { name: STORES.pendingSubmissions, keyPath: 'id' }
+  ];
 
 /** Cached DB connection promise, reused across calls. */
 let dbPromise: Promise<IDBDatabase> | null = null;

--- a/src/lib/pwa-install.ts
+++ b/src/lib/pwa-install.ts
@@ -1,0 +1,57 @@
+/**
+ * PWA install prompt handling.
+ * Captures the Chromium-only beforeinstallprompt event, defers it, and
+ * exposes canInstall()/installPwa() so UI can offer installation on
+ * demand. iOS Safari never fires the event and is untouched.
+ */
+
+type BeforeInstallPromptEvent = Event & {
+  prompt: () => Promise<void>;
+};
+
+let deferredPrompt: BeforeInstallPromptEvent | null = null;
+let installed = false;
+
+/** True when the browser has offered an install prompt not yet acted on. */
+export function canInstall(): boolean {
+  return deferredPrompt !== null && !installed;
+}
+
+/** Shows the deferred install prompt, if one is captured. */
+export async function installPwa(): Promise<void> {
+  const prompt = deferredPrompt;
+  if (!prompt) return;
+  await prompt.prompt();
+  deferredPrompt = null;
+}
+
+/**
+ * Starts capturing install events. Calls onChange whenever the
+ * installability state changes. Returns an unsubscribe function.
+ */
+export function setupInstallPrompt(onChange?: () => void): () => void {
+  if (typeof window === 'undefined') {
+    return () => {
+      // SSR: no listeners were registered.
+    };
+  }
+
+  const onBeforeInstall = (event: Event) => {
+    event.preventDefault();
+    deferredPrompt = event as BeforeInstallPromptEvent;
+    onChange?.();
+  };
+  const onInstalled = () => {
+    installed = true;
+    deferredPrompt = null;
+    onChange?.();
+  };
+
+  window.addEventListener('beforeinstallprompt', onBeforeInstall);
+  window.addEventListener('appinstalled', onInstalled);
+
+  return () => {
+    window.removeEventListener('beforeinstallprompt', onBeforeInstall);
+    window.removeEventListener('appinstalled', onInstalled);
+  };
+}

--- a/src/lib/pwa-install.ts
+++ b/src/lib/pwa-install.ts
@@ -36,11 +36,14 @@ export function setupInstallPrompt(onChange?: () => void): () => void {
     };
   }
 
+  /** Captures the install prompt for later use by installPwa(). */
   const onBeforeInstall = (event: Event) => {
     event.preventDefault();
     deferredPrompt = event as BeforeInstallPromptEvent;
     onChange?.();
   };
+
+  /** Marks the app as installed and clears the deferred prompt. */
   const onInstalled = () => {
     installed = true;
     deferredPrompt = null;

--- a/src/lib/submission-queue.ts
+++ b/src/lib/submission-queue.ts
@@ -1,0 +1,149 @@
+/* eslint-disable @typescript-eslint/no-floating-promises */
+import {
+  dbDelete,
+  dbGetAll,
+  dbGetAllKeys,
+  dbSet,
+  STORES,
+  type PendingSubmission
+} from '@/lib/indexeddb';
+
+/** Background Sync tag used to trigger a replay when connectivity returns. */
+export const SYNC_TAG = 'replay-pending';
+
+/** Message the service worker broadcasts when a sync event fires. */
+export const SYNC_REPLAY_MESSAGE = 'SYNC_REPLAY';
+
+/** Minimal SyncManager surface used to request a background replay. */
+type SyncManagerLike = {
+  register(tag: string): Promise<void>;
+};
+
+/** Handlers replay a queued payload and reject when it still cannot be sent. */
+type SubmissionHandler = (payload: unknown) => Promise<void>;
+
+const handlers = new Map<string, SubmissionHandler>();
+
+/** Generates a unique id for a queued submission. */
+function generateId(): string {
+  if (
+    typeof crypto !== 'undefined' &&
+    typeof crypto.randomUUID === 'function'
+  ) {
+    return crypto.randomUUID();
+  }
+  return `pending-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+}
+
+/**
+ * Stores a submission that failed to send so it can be replayed later.
+ * Also registers a background sync tag where supported (best effort).
+ */
+export async function enqueueSubmission(
+  kind: string,
+  payload: unknown,
+  ownerId = ''
+): Promise<PendingSubmission> {
+  const entry: PendingSubmission = {
+    id: generateId(),
+    ownerId,
+    kind,
+    payload,
+    createdAt: Date.now(),
+    attempts: 0
+  };
+  await dbSet(STORES.pendingSubmissions, entry);
+  registerBackgroundSync();
+  return entry;
+}
+
+/** Removes a queued submission by id. */
+export async function removeSubmission(id: string): Promise<void> {
+  await dbDelete(STORES.pendingSubmissions, id);
+}
+
+/** Lists all queued submissions. */
+export async function listPendingSubmissions(): Promise<PendingSubmission[]> {
+  return dbGetAll<PendingSubmission>(STORES.pendingSubmissions);
+}
+
+/** Returns the number of queued submissions. */
+export async function pendingCount(): Promise<number> {
+  const keys = await dbGetAllKeys(STORES.pendingSubmissions);
+  return keys.length;
+}
+
+/** Registers the replay handler used for a submission kind. */
+export function registerSubmissionHandler(
+  kind: string,
+  handler: SubmissionHandler
+): void {
+  handlers.set(kind, handler);
+}
+
+/**
+ * Replays all queued submissions through their registered handlers.
+ * Successful submissions are removed; failed ones keep their entry
+ * with an incremented attempt count. Unknown kinds are skipped.
+ */
+export async function replayPendingSubmissions(): Promise<void> {
+  const items = await listPendingSubmissions();
+  for (const item of items) {
+    const handler = handlers.get(item.kind);
+    if (!handler) continue;
+    try {
+      await handler(item.payload);
+      await removeSubmission(item.id);
+    } catch (error) {
+      console.warn('[submission-queue] replay failed for', item.id, error);
+      await dbSet(STORES.pendingSubmissions, {
+        ...item,
+        attempts: item.attempts + 1
+      });
+    }
+  }
+}
+
+/**
+ * Requests a background sync replay where SyncManager is supported.
+ * Silently no-ops on browsers without it (e.g. iOS Safari).
+ */
+export async function registerBackgroundSync(): Promise<void> {
+  try {
+    if (
+      typeof navigator === 'undefined' ||
+      !navigator.serviceWorker ||
+      !('serviceWorker' in navigator)
+    ) {
+      return;
+    }
+    const registration = await navigator.serviceWorker.ready;
+    if (!('sync' in registration)) return;
+    const withSync = registration as unknown as { sync: SyncManagerLike };
+    await withSync.sync.register(SYNC_TAG);
+  } catch {
+    // Best effort only — the online event and page-load replay are the baseline.
+  }
+}
+
+/**
+ * Listens for SYNC_REPLAY messages from the service worker and replays
+ * the queue. Returns an unsubscribe function.
+ */
+export function listenForSyncReplay(): () => void {
+  if (typeof navigator === 'undefined' || !navigator.serviceWorker) {
+    return () => {
+      // No service worker available — nothing to unsubscribe.
+    };
+  }
+  const onMessage = (event: MessageEvent): void => {
+    const data = event.data as { type?: string } | null;
+    if (data?.type === SYNC_REPLAY_MESSAGE) {
+      replayPendingSubmissions();
+    }
+  };
+  navigator.serviceWorker.addEventListener('message', onMessage);
+  return () => {
+    navigator.serviceWorker.removeEventListener('message', onMessage);
+  };
+}

--- a/src/lib/submission-queue.ts
+++ b/src/lib/submission-queue.ts
@@ -32,8 +32,15 @@ function generateId(): string {
   ) {
     return crypto.randomUUID();
   }
-  // NOSONAR - non-security fallback id; crypto.randomUUID is the primary path
-  return `pending-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+  // Fallback for engines without crypto.randomUUID: CSPRNG segment.
+  if (
+    typeof crypto !== 'undefined' &&
+    typeof crypto.getRandomValues === 'function'
+  ) {
+    const buffer = crypto.getRandomValues(new Uint32Array(2));
+    return `pending-${Date.now()}-${buffer[0].toString(36)}${buffer[1].toString(36)}`;
+  }
+  return `pending-${Date.now()}`;
 }
 
 /**

--- a/src/lib/submission-queue.ts
+++ b/src/lib/submission-queue.ts
@@ -32,6 +32,7 @@ function generateId(): string {
   ) {
     return crypto.randomUUID();
   }
+  // NOSONAR - non-security fallback id; crypto.randomUUID is the primary path
   return `pending-${Date.now()}-${Math.random().toString(36).slice(2)}`;
 }
 

--- a/src/lib/submission-queue.ts
+++ b/src/lib/submission-queue.ts
@@ -63,7 +63,7 @@ export async function removeSubmission(id: string): Promise<void> {
 }
 
 /** Lists all queued submissions. */
-export async function listPendingSubmissions(): Promise<PendingSubmission[]> {
+export function listPendingSubmissions(): Promise<PendingSubmission[]> {
   return dbGetAll<PendingSubmission>(STORES.pendingSubmissions);
 }
 
@@ -136,6 +136,8 @@ export function listenForSyncReplay(): () => void {
       // No service worker available — nothing to unsubscribe.
     };
   }
+
+  /** Replays the queue when the service worker broadcasts a sync message. */
   const onMessage = (event: MessageEvent): void => {
     const data = event.data as { type?: string } | null;
     if (data?.type === SYNC_REPLAY_MESSAGE) {

--- a/src/lib/submission-replay.ts
+++ b/src/lib/submission-replay.ts
@@ -1,0 +1,41 @@
+import { getAppQueryClient } from '@/components/general/query-provider';
+import { registerSubmissionHandler } from '@/lib/submission-queue';
+import { getAPI } from '@/services/api';
+
+/** Kind for a queued questionnaire response submission. */
+export const QUESTIONNAIRE_RESPONSE_KIND = 'questionnaire-response';
+
+/** Kind for a queued SOAP bundle submission. */
+export const SOAP_BUNDLE_KIND = 'soap-bundle';
+
+/** True when an axios-style error means no HTTP response was received. */
+export function isNetworkError(error: unknown): boolean {
+  if (typeof error !== 'object' || error === null) return false;
+  const err = error as { response?: unknown; code?: string };
+  return err.response === undefined || err.code === 'ERR_NETWORK';
+}
+
+/**
+ * Registers replay handlers for offline-queued submissions.
+ * Call once at app startup so page-load replays can dispatch.
+ */
+export function registerSubmissionReplayHandlers(): void {
+  registerSubmissionHandler(
+    QUESTIONNAIRE_RESPONSE_KIND,
+    async (payload: unknown) => {
+      const API = await getAPI();
+      await API.post('/fhir/QuestionnaireResponse', payload);
+      // Reflect the synced contribution in research progress widgets.
+      // skipcq: JS-0098 - fire-and-forget query invalidation
+      const queryClient = getAppQueryClient();
+      if (queryClient) {
+        void queryClient.invalidateQueries({ queryKey: ['research'] });
+      }
+    }
+  );
+
+  registerSubmissionHandler(SOAP_BUNDLE_KIND, async (payload: unknown) => {
+    const API = await getAPI();
+    await API.post('/fhir', payload);
+  });
+}

--- a/src/lib/submission-replay.ts
+++ b/src/lib/submission-replay.ts
@@ -26,9 +26,9 @@ export function registerSubmissionReplayHandlers(): void {
       const API = await getAPI();
       await API.post('/fhir/QuestionnaireResponse', payload);
       // Reflect the synced contribution in research progress widgets.
-      // skipcq: JS-0098 - fire-and-forget query invalidation
       const queryClient = getAppQueryClient();
       if (queryClient) {
+        // skipcq: JS-0098 - fire-and-forget query invalidation
         void queryClient.invalidateQueries({ queryKey: ['research'] });
       }
     }

--- a/src/lib/sw-update.tsx
+++ b/src/lib/sw-update.tsx
@@ -1,0 +1,82 @@
+'use client';
+
+import { useEffect } from 'react';
+import { toast } from 'react-toastify';
+
+/** Message the service worker listens for to skip waiting. */
+export const SKIP_WAITING_MESSAGE = 'SKIP_WAITING';
+
+/**
+ * Reloads the app with the updated service worker. If a worker is
+ * waiting, it is told to skip waiting and the page reloads once it
+ * takes control; otherwise the page reloads immediately.
+ */
+export function applySwUpdate(registration: ServiceWorkerRegistration): void {
+  if (registration.waiting) {
+    navigator.serviceWorker.addEventListener('controllerchange', () => {
+      window.location.reload();
+    });
+    registration.waiting.postMessage({ type: SKIP_WAITING_MESSAGE });
+  } else {
+    window.location.reload();
+  }
+}
+
+/** Shows the update-available toast with a reload action. */
+function notifyUpdate(registration: ServiceWorkerRegistration): void {
+  const toastId = toast.info(
+    <div className='flex items-center gap-3'>
+      <span>Update available</span>
+      <button
+        type='button'
+        className='cursor-pointer font-semibold text-teal-600 underline'
+        onClick={() => {
+          toast.dismiss(toastId);
+          applySwUpdate(registration);
+        }}
+      >
+        Reload
+      </button>
+    </div>,
+    { autoClose: false, closeOnClick: false }
+  );
+}
+
+/**
+ * Watches the service worker registration for updates and notifies the
+ * user when a new version is installed. Returns an unsubscribe function.
+ */
+export function setupSwUpdateDetection(): () => void {
+  if (typeof navigator === 'undefined' || !('serviceWorker' in navigator)) {
+    return () => {
+      // Service workers unsupported — nothing to watch.
+    };
+  }
+
+  let active = true;
+  // skipcq: JS-0098 - fire-and-forget; the registration promise resolves async
+  void (async () => {
+    const registration = await navigator.serviceWorker.ready;
+    if (!active) return;
+    registration.addEventListener('updatefound', () => {
+      const newWorker = registration.installing;
+      if (!newWorker) return;
+      newWorker.addEventListener('statechange', () => {
+        const isUpdate = navigator.serviceWorker.controller !== null;
+        if (newWorker.state === 'installed' && isUpdate) {
+          notifyUpdate(registration);
+        }
+      });
+    });
+  })();
+
+  return () => {
+    active = false;
+  };
+}
+
+/** Mounts SW update detection for the lifetime of the app. */
+export default function SwUpdateDetector() {
+  useEffect(() => setupSwUpdateDetection(), []);
+  return null;
+}

--- a/src/services/__tests__/assessment-offline-queue.test.tsx
+++ b/src/services/__tests__/assessment-offline-queue.test.tsx
@@ -1,0 +1,192 @@
+import { enqueueSubmission } from '@/lib/submission-queue';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { act, renderHook } from '@testing-library/react';
+import type { AxiosInstance } from 'axios';
+import type { Bundle, QuestionnaireResponse } from 'fhir/r4';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { getAPI } from '../api';
+import { useSubmitQuestionnaire, useSubmitSoapBundle } from '../api/assessment';
+
+vi.mock('../api', () => ({ getAPI: vi.fn() }));
+
+vi.mock('../anonymous-session', () => ({
+  ensureAnonymousSession: vi.fn(),
+  buildAnonymousIdentifier: vi.fn()
+}));
+
+vi.mock('@/lib/indexeddb', () => ({
+  STORES: {
+    assessmentDrafts: 'assessment_drafts',
+    pendingSubmissions: 'pending_submissions'
+  },
+  dbDelete: vi.fn(() => Promise.resolve())
+}));
+
+vi.mock('@/lib/submission-queue', async importOriginal => {
+  const actual =
+    await importOriginal<typeof import('@/lib/submission-queue')>();
+  return { ...actual, enqueueSubmission: vi.fn() };
+});
+
+import {
+  buildAnonymousIdentifier,
+  ensureAnonymousSession
+} from '../anonymous-session';
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } }
+  });
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+  };
+}
+
+const MOCK_QR: QuestionnaireResponse = {
+  resourceType: 'QuestionnaireResponse',
+  id: 'QR-1',
+  questionnaire: 'Questionnaire/phq2',
+  status: 'completed',
+  item: []
+};
+
+const NETWORK_ERROR = { code: 'ERR_NETWORK' };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('offline submission queue', () => {
+  it('queues the prepared payload on network failure instead of throwing', async () => {
+    const mockPost = vi.fn().mockRejectedValue(NETWORK_ERROR);
+    vi.mocked(getAPI).mockResolvedValue({
+      post: mockPost
+    } as unknown as AxiosInstance);
+    const mockEnqueue = vi.mocked(enqueueSubmission).mockResolvedValue({
+      id: 'q1',
+      ownerId: '',
+      kind: 'questionnaire-response',
+      payload: {},
+      createdAt: 1,
+      attempts: 0
+    });
+
+    const { result } = renderHook(() => useSubmitQuestionnaire('phq2', true), {
+      wrapper: createWrapper()
+    });
+
+    let outcome: unknown;
+    await act(async () => {
+      outcome = await result.current.mutateAsync(MOCK_QR);
+    });
+
+    expect(outcome).toMatchObject({ queued: true });
+    expect(mockPost).toHaveBeenCalledWith(
+      '/fhir/QuestionnaireResponse',
+      expect.objectContaining({ status: 'completed' })
+    );
+    expect(mockEnqueue).toHaveBeenCalledTimes(1);
+    const [kind, payload] = mockEnqueue.mock.calls[0];
+    expect(kind).toBe('questionnaire-response');
+    expect(payload).toMatchObject({
+      resourceType: 'QuestionnaireResponse',
+      status: 'completed',
+      questionnaire: 'https://konsulin.care/fhir/Questionnaire/phq2'
+    });
+  });
+
+  it('rethrows non-network errors without queueing', async () => {
+    const mockPost = vi.fn().mockRejectedValue({
+      response: { status: 500 },
+      message: 'Server error'
+    });
+    vi.mocked(getAPI).mockResolvedValue({
+      post: mockPost
+    } as unknown as AxiosInstance);
+
+    const { result } = renderHook(() => useSubmitQuestionnaire('phq2', true), {
+      wrapper: createWrapper()
+    });
+
+    await act(async () => {
+      await expect(result.current.mutateAsync(MOCK_QR)).rejects.toBeDefined();
+    });
+
+    expect(enqueueSubmission).not.toHaveBeenCalled();
+  });
+
+  it('queues even when the anonymous session call fails offline', async () => {
+    vi.mocked(ensureAnonymousSession).mockRejectedValue(NETWORK_ERROR);
+    vi.mocked(buildAnonymousIdentifier).mockReturnValue({
+      system: 'https://konsulin.care/fhir/CodeSystem/anonymous-session',
+      value: 'guest-1'
+    });
+    const mockPost = vi.fn().mockRejectedValue(NETWORK_ERROR);
+    vi.mocked(getAPI).mockResolvedValue({
+      post: mockPost
+    } as unknown as AxiosInstance);
+    const mockEnqueue = vi.mocked(enqueueSubmission).mockResolvedValue({
+      id: 'q2',
+      ownerId: 'guest-1',
+      kind: 'questionnaire-response',
+      payload: {},
+      createdAt: 1,
+      attempts: 0
+    });
+
+    const { result } = renderHook(() => useSubmitQuestionnaire('phq2', false), {
+      wrapper: createWrapper()
+    });
+
+    let outcome: unknown;
+    await act(async () => {
+      outcome = await result.current.mutateAsync(MOCK_QR);
+    });
+
+    expect(outcome).toMatchObject({ queued: true });
+    expect(mockEnqueue).toHaveBeenCalledTimes(1);
+  });
+
+  it('queues a SOAP bundle on network failure', async () => {
+    const mockPost = vi.fn().mockRejectedValue(NETWORK_ERROR);
+    vi.mocked(getAPI).mockResolvedValue({
+      post: mockPost
+    } as unknown as AxiosInstance);
+    const mockEnqueue = vi.mocked(enqueueSubmission).mockResolvedValue({
+      id: 'q3',
+      ownerId: '',
+      kind: 'soap-bundle',
+      payload: {},
+      createdAt: 1,
+      attempts: 0
+    });
+
+    const { result } = renderHook(() => useSubmitSoapBundle(), {
+      wrapper: createWrapper()
+    });
+
+    const bundle = {
+      resourceType: 'Bundle',
+      type: 'transaction',
+      entry: []
+    } as Bundle;
+
+    let outcome: unknown;
+    await act(async () => {
+      outcome = await result.current.mutateAsync(bundle);
+    });
+
+    expect(outcome).toMatchObject({ queued: true });
+    expect(mockPost).toHaveBeenCalledWith('/fhir', bundle);
+    expect(mockEnqueue).toHaveBeenCalledTimes(1);
+    const [kind, payload] = mockEnqueue.mock.calls[0];
+    expect(kind).toBe('soap-bundle');
+    expect(payload).toEqual(bundle);
+  });
+});

--- a/src/services/api.tsx
+++ b/src/services/api.tsx
@@ -1,6 +1,8 @@
 /* eslint-disable @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-argument */
+import { getRetryDelayMs, shouldRetryRequest } from '@/lib/api-retry';
+import { reportRequestOutcome } from '@/lib/connectivity';
 import { clearUserData } from '@/lib/indexeddb';
-import axios, { AxiosInstance } from 'axios';
+import axios, { AxiosInstance, type InternalAxiosRequestConfig } from 'axios';
 import { toast } from 'react-toastify';
 import { parseAxiosError } from './api-error';
 
@@ -87,11 +89,40 @@ export function getAPI(options?: {
   return Promise.resolve(instance);
 }
 
+/** Request config with the retry counter attached by the interceptor. */
+type RetryableConfig = InternalAxiosRequestConfig & {
+  _retryCount?: number;
+};
+
 /** Attach the shared response interceptor to an Axios instance. */
 function setupResponseInterceptor(instance: AxiosInstance) {
   instance.interceptors.response.use(
-    response => response,
+    response => {
+      reportRequestOutcome(true);
+      return response;
+    },
     error => {
+      const config = error.config as RetryableConfig | undefined;
+      const retryCount = config?._retryCount ?? 0;
+
+      // Retry idempotent GETs (network failures / 5xx) with backoff before
+      // surfacing the error, so toasts and the auth redirect only fire once
+      // the retry budget is exhausted.
+      if (shouldRetryRequest(error, config, retryCount)) {
+        const retryAfterBackoff = async (): Promise<unknown> => {
+          await new Promise(resolve =>
+            setTimeout(resolve, getRetryDelayMs(retryCount))
+          );
+          if (config) {
+            config._retryCount = retryCount + 1;
+          }
+          return instance.request(config as InternalAxiosRequestConfig);
+        };
+        return retryAfterBackoff();
+      }
+
+      reportRequestOutcome(false);
+
       const { errorMessage, isExpiredToken, isMissingToken } =
         parseAxiosError(error);
 

--- a/src/services/api.tsx
+++ b/src/services/api.tsx
@@ -109,6 +109,7 @@ function setupResponseInterceptor(instance: AxiosInstance) {
       // surfacing the error, so toasts and the auth redirect only fire once
       // the retry budget is exhausted.
       if (shouldRetryRequest(error, config, retryCount)) {
+        /** Waits for the backoff delay, then re-issues the request with the retry counter bumped. */
         const retryAfterBackoff = async (): Promise<unknown> => {
           await new Promise(resolve =>
             setTimeout(resolve, getRetryDelayMs(retryCount))

--- a/src/services/api/assessment.tsx
+++ b/src/services/api/assessment.tsx
@@ -1,5 +1,11 @@
 /* eslint-disable max-lines */
-import { STORES, dbDelete } from '@/lib/indexeddb';
+import { dbDelete, STORES } from '@/lib/indexeddb';
+import { enqueueSubmission } from '@/lib/submission-queue';
+import {
+  isNetworkError,
+  QUESTIONNAIRE_RESPONSE_KIND,
+  SOAP_BUNDLE_KIND
+} from '@/lib/submission-replay';
 import { IQuestionnaireResponse } from '@/types/assessment';
 import { toCanonicalQuestionnaireUrl } from '@/utils/fhir/questionnaire-url';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
@@ -74,6 +80,13 @@ export const RESULT_BRIEF_PLACEHOLDER =
 
 export const RESULT_BRIEF_LOGIN_REQUIRED =
   'Kindly log in to generate the result brief.';
+
+/**
+ * Returned by submission mutations when the response was queued for
+ * offline replay instead of being sent. Kept opaque so callers can
+ * detect the queued state without changing the mutation's public type.
+ */
+export const OFFLINE_QUEUED = { queued: true } as const;
 
 const POLL_INTERVAL_MS = 1000; // 1 request per second
 const MAX_WAIT_MS = 3000; // max 3 seconds total
@@ -214,8 +227,16 @@ export const useSubmitSoapBundle = () => {
     mutationKey: ['soap-response'],
     mutationFn: async (bundle: Bundle) => {
       const API = await getAPI();
-      const response = await API.post<Bundle>('/fhir', bundle);
-      return response.data;
+      try {
+        const response = await API.post<Bundle>('/fhir', bundle);
+        return response.data;
+      } catch (error) {
+        if (isNetworkError(error)) {
+          await enqueueSubmission(SOAP_BUNDLE_KIND, bundle);
+          return OFFLINE_QUEUED as unknown as Bundle;
+        }
+        throw error;
+      }
     }
   });
 };
@@ -237,33 +258,57 @@ export const useSubmitQuestionnaire = (
       const API = await getAPI();
 
       let identifier = questionnaireResponse.identifier;
+      let ownerId = '';
       if (!isAuthenticated) {
-        const guestId = await ensureAnonymousSession(false);
-        identifier = buildAnonymousIdentifier(guestId);
-      }
-
-      const response = await API.post<QuestionnaireResponse>(
-        '/fhir/QuestionnaireResponse',
-        {
-          author,
-          item,
-          identifier,
-          resourceType,
-          questionnaire: toCanonicalQuestionnaireUrl(questionnaireId),
-          status: 'completed',
-          authored: timestamp,
-          subject
+        try {
+          const guestId = await ensureAnonymousSession(false);
+          identifier = buildAnonymousIdentifier(guestId);
+          ownerId = guestId;
+        } catch (error) {
+          // Offline anonymous: keep any existing identifier and let the
+          // queue replay the fully-prepared payload once back online.
+          if (!isNetworkError(error)) throw error;
         }
-      );
-
-      // Only delete draft after successful server submission.
-      if (isAuthenticated) {
-        dbDelete(STORES.assessmentDrafts, ['', questionnaireId]).catch(
-          (err: unknown) => console.warn('[IndexedDB]', err)
-        );
       }
 
-      return response.data;
+      const payload = {
+        author,
+        item,
+        identifier,
+        resourceType,
+        questionnaire: toCanonicalQuestionnaireUrl(questionnaireId),
+        status: 'completed',
+        authored: timestamp,
+        subject
+      };
+
+      try {
+        const response = await API.post<QuestionnaireResponse>(
+          '/fhir/QuestionnaireResponse',
+          payload
+        );
+
+        // Only delete draft after successful server submission.
+        if (isAuthenticated) {
+          dbDelete(STORES.assessmentDrafts, ['', questionnaireId]).catch(
+            (err: unknown) => console.warn('[IndexedDB]', err)
+          );
+        }
+
+        return response.data;
+      } catch (error) {
+        // Network-level failure: queue for replay instead of failing the
+        // submission. The marker keeps the mutation's public type stable.
+        if (isNetworkError(error)) {
+          await enqueueSubmission(
+            QUESTIONNAIRE_RESPONSE_KIND,
+            payload,
+            ownerId
+          );
+          return OFFLINE_QUEUED as unknown as QuestionnaireResponse;
+        }
+        throw error;
+      }
     },
     onSuccess: () => {
       // Reflect the new contribution in research progress widgets.


### PR DESCRIPTION
## Summary

Finalizes PWA support: offline submission queue with SW replay, pending submissions banner, install prompt, SW update detection with reload prompt, cached Questionnaire reads with GET retries, and a connectivity indicator.

## Changes

- Offline submission queue + replay via SW sync
- Pending submissions banner with manual sync
- Install prompt handling with install button
- SW update detection and reload prompt
- Cache Questionnaire reads, retry GETs, connectivity bar
- Isolate PWA mounts in render tests

## Testing

- [ ] Tests pass (`pnpm test`)
- [ ] ESLint clean